### PR TITLE
Upgrade BundlerMinifier.Core

### DIFF
--- a/src/CleanArchitecture.Web/CleanArchitecture.Web.csproj
+++ b/src/CleanArchitecture.Web/CleanArchitecture.Web.csproj
@@ -32,7 +32,7 @@
   </Target>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.2.301" />
+    <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.8.391" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes error on dotnet publish:

It was not possible to find any compatible framework version
  The specified framework 'Microsoft.NETCore.App', version '1.0.0' was not found.