### PR TITLE
Converted domain events to async

### DIFF
--- a/src/CleanArchitecture.Core/Interfaces/IDomainEventDispatcher.cs
+++ b/src/CleanArchitecture.Core/Interfaces/IDomainEventDispatcher.cs
@@ -1,9 +1,10 @@
-﻿using CleanArchitecture.Core.SharedKernel;
+﻿using System.Threading.Tasks;
+using CleanArchitecture.Core.SharedKernel;
 
 namespace CleanArchitecture.Core.Interfaces
 {
     public interface IDomainEventDispatcher
     {
-        void Dispatch(BaseDomainEvent domainEvent);
+        Task Dispatch(BaseDomainEvent domainEvent);
     }
 }

--- a/src/CleanArchitecture.Core/Interfaces/IHandle.cs
+++ b/src/CleanArchitecture.Core/Interfaces/IHandle.cs
@@ -1,9 +1,10 @@
-﻿using CleanArchitecture.Core.SharedKernel;
+﻿using System.Threading.Tasks;
+using CleanArchitecture.Core.SharedKernel;
 
 namespace CleanArchitecture.Core.Interfaces
 {
-    public interface IHandle<T> where T : BaseDomainEvent
+    public interface IHandle<in T> where T : BaseDomainEvent
     {
-        void Handle(T domainEvent);
+        Task Handle(T domainEvent);
     }
 }

--- a/src/CleanArchitecture.Core/Services/ToDoItemService.cs
+++ b/src/CleanArchitecture.Core/Services/ToDoItemService.cs
@@ -1,4 +1,5 @@
-﻿using Ardalis.GuardClauses;
+﻿using System.Threading.Tasks;
+using Ardalis.GuardClauses;
 using CleanArchitecture.Core.Events;
 using CleanArchitecture.Core.Interfaces;
 
@@ -6,11 +7,13 @@ namespace CleanArchitecture.Core.Services
 {
     public class ToDoItemService : IHandle<ToDoItemCompletedEvent>
     {
-        public void Handle(ToDoItemCompletedEvent domainEvent)
+        public Task Handle(ToDoItemCompletedEvent domainEvent)
         {
             Guard.Against.Null(domainEvent, nameof(domainEvent));
 
             // Do Nothing
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/CleanArchitecture.Infrastructure/DomainEvents/DomainEventDispatcher.cs
+++ b/src/CleanArchitecture.Infrastructure/DomainEvents/DomainEventDispatcher.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace CleanArchitecture.Infrastructure.DomainEvents
 {
@@ -19,7 +20,7 @@ namespace CleanArchitecture.Infrastructure.DomainEvents
             _container = container;
         }
 
-        public void Dispatch(BaseDomainEvent domainEvent)
+        public async Task Dispatch(BaseDomainEvent domainEvent)
         {
             Type handlerType = typeof(IHandle<>).MakeGenericType(domainEvent.GetType());
             Type wrapperType = typeof(DomainEventHandler<>).MakeGenericType(domainEvent.GetType());
@@ -29,13 +30,13 @@ namespace CleanArchitecture.Infrastructure.DomainEvents
 
             foreach (DomainEventHandler handler in wrappedHandlers)
             {
-                handler.Handle(domainEvent);
+                await handler.Handle(domainEvent).ConfigureAwait(false);
             }
         }
 
         private abstract class DomainEventHandler
         {
-            public abstract void Handle(BaseDomainEvent domainEvent);
+            public abstract Task Handle(BaseDomainEvent domainEvent);
         }
 
         private class DomainEventHandler<T> : DomainEventHandler
@@ -48,9 +49,9 @@ namespace CleanArchitecture.Infrastructure.DomainEvents
                 _handler = handler;
             }
 
-            public override void Handle(BaseDomainEvent domainEvent)
+            public override Task Handle(BaseDomainEvent domainEvent)
             {
-                _handler.Handle((T)domainEvent);
+                return _handler.Handle((T)domainEvent);
             }
         }
     }

--- a/tests/CleanArchitecture.Tests/NoOpDomainEventDispatcher.cs
+++ b/tests/CleanArchitecture.Tests/NoOpDomainEventDispatcher.cs
@@ -1,10 +1,14 @@
-﻿using CleanArchitecture.Core.Interfaces;
+﻿using System.Threading.Tasks;
+using CleanArchitecture.Core.Interfaces;
 using CleanArchitecture.Core.SharedKernel;
 
 namespace CleanArchitecture.Tests
 {
     public class NoOpDomainEventDispatcher : IDomainEventDispatcher
     {
-        public void Dispatch(BaseDomainEvent domainEvent) { }
+        public Task Dispatch(BaseDomainEvent domainEvent)
+        {
+            return Task.CompletedTask;
+        }
     }
 }


### PR DESCRIPTION
Sometimes we want to perform long running task in domain events. For example we may want to send an email when an entity is added or modified. To support this type of functionality, domain event handlers should support async methods.