### PR TITLE
.NET Core 3.0, csprojs cleanup, add generic setup

### DIFF
--- a/CleanArchitecture.sln
+++ b/CleanArchitecture.sln
@@ -18,14 +18,19 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{250F283E-FE2F-4BBD-9E63-A2265B84E23F}"
 	ProjectSection(SolutionItems) = preProject
 		azure-pipelines.yml = azure-pipelines.yml
+		DeploymentSettings.props = DeploymentSettings.props
+		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
+		nuget.config = nuget.config
+		Packages.props = Packages.props
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CleanArchitecture.FunctionalTests", "tests\CleanArchitecture.FunctionalTests\CleanArchitecture.FunctionalTests.csproj", "{7D84EFEE-A7D9-44AD-A0A3-38EC7882D94C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CleanArchitecture.FunctionalTests", "tests\CleanArchitecture.FunctionalTests\CleanArchitecture.FunctionalTests.csproj", "{7D84EFEE-A7D9-44AD-A0A3-38EC7882D94C}"
 	ProjectSection(ProjectDependencies) = postProject
 		{C9751CB7-4CD6-4633-A99A-4F6ADD525437} = {C9751CB7-4CD6-4633-A99A-4F6ADD525437}
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CleanArchitecture.IntegrationTests", "tests\CleanArchitecture.IntegrationTests\CleanArchitecture.IntegrationTests.csproj", "{0776DC14-9000-47A4-A3F4-ECBCF8CEBC17}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CleanArchitecture.IntegrationTests", "tests\CleanArchitecture.IntegrationTests\CleanArchitecture.IntegrationTests.csproj", "{0776DC14-9000-47A4-A3F4-ECBCF8CEBC17}"
 	ProjectSection(ProjectDependencies) = postProject
 		{220361D6-9C76-4E3F-BD34-3C7B50E2CA4D} = {220361D6-9C76-4E3F-BD34-3C7B50E2CA4D}
 	EndProjectSection

--- a/DeploymentSettings.props
+++ b/DeploymentSettings.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <DeployNugetPackages>false</DeployNugetPackages>
+  </PropertyGroup>
+
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="DeploymentSettings.props" />
+
+  <PropertyGroup>
+    <Company>Clean Architecture</Company>
+    <Authors>$(Company)</Authors>
+    <Copyright>Copyright © $(Company) $([System.DateTime]::Now.Year)</Copyright>
+    <Trademark>$(Company)™</Trademark>
+    <Product>$(Company) Projects</Product>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
+    <NoWarn>1591;1701;1702;8032;NU1701;AD0001</NoWarn>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="content\*" Pack="true" PackagePath="content" />
+    <None Include="build\*" Pack="true" PackagePath="build" />
+    <None Include="lib\*" Pack="true" PackagePath="lib" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="Exists('$(MSBuildProjectDirectory)\xunit.runner.json')">
+    <None Update="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(WebProjectMode)' == 'true'">
+    <Content Update="wwwroot\**\*;Views\**\*;Areas\**\Views;appsettings.json;web.config">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    
+    <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.8.391" />
+    
+    <Content Update="Pages\_ViewImports.cshtml">
+      <Pack>$(IncludeRazorContentInPack)</Pack>
+    </Content>
+    <Content Update="Pages\_ViewStart.cshtml">
+      <Pack>$(IncludeRazorContentInPack)</Pack>
+    </Content>
+  </ItemGroup>
+  
+  <PropertyGroup Condition="'$(TestProjectMode)' == 'true'">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup Label="Scripts">
+    <PowerShell>powershell -NoProfile -ExecutionPolicy Unrestricted -command</PowerShell>
+    <Pack>dotnet pack &quot;$(MSBuildProjectDirectory)\$(ProjectFileName)&quot; --no-build -o C:\NugetSource -c $(Configuration)</Pack>
+  </PropertyGroup>
+
+  <Target Name="PackNugets" AfterTargets="AfterBuild" Condition="'$(DeployNugetPackages)'=='true'">
+    <Exec Command="$(Pack)"/>
+  </Target>
+  
+  <!-- https://github.com/NuGet/Home/issues/4412. -->
+  <Target Name="CopyDepsFiles" AfterTargets="Build" Condition="'$(TargetFramework)'!=''">
+    <ItemGroup>
+      <DepsFilePaths Include="$([System.IO.Path]::ChangeExtension('%(_ResolvedProjectReferencePaths.FullPath)', '.deps.json'))" />
+    </ItemGroup>
+    <Copy SourceFiles="%(DepsFilePaths.FullPath)" DestinationFolder="$(OutputPath)" Condition="Exists('%(DepsFilePaths.FullPath)')" />
+  </Target>
+  
+  <Target Name="PrepublishScript" BeforeTargets="PrepareForPublish" Condition="'$(WebProjectMode)' == 'true'">
+    <Exec Command="bower install" />
+    <Exec Command="dotnet bundle" />
+  </Target>
+</Project>

--- a/Packages.props
+++ b/Packages.props
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <PackageReference Update="ReportGenerator" Version="4.2.20" />
+    <PackageReference Update="Moq" Version="4.13.0" />
+    
+    <PackageReference Update="Autofac" Version="4.9.4" />
+    <PackageReference Update="Autofac.Extensions.DependencyInjection" Version="5.0.0" />
+    <PackageReference Update="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0" />
+    <PackageReference Update="Microsoft.Web.LibraryManager.Build" Version="2.0.76" />
+    <PackageReference Update="Swashbuckle.AspNetCore" Version="5.0.0-rc3" />
+    <PackageReference Update="SQLite" Version="3.13.0" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Sqlite" Version="3.0.0" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.0" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Tools" Version="3.0.0" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.InMemory" Version="3.0.0" />
+    <PackageReference Update="Ardalis.EFCore.Extensions" Version="1.1.0" />
+    <PackageReference Update="Ardalis.GuardClauses" Version="1.2.9" />
+    <PackageReference Update="NETStandard.Library" Version="2.0.3" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TestProjectMode)' == 'true'">
+    <PackageReference Include="coverlet.msbuild" Version="2.7.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.4.1" PrivateAssets="all" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/Packages.props
+++ b/Packages.props
@@ -20,6 +20,7 @@
   </ItemGroup>
   
   <ItemGroup Condition="'$(TestProjectMode)' == 'true'">
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="coverlet.msbuild" Version="2.7.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.0.0" />

--- a/nuget.config
+++ b/nuget.config
@@ -6,7 +6,7 @@
     </packageRestore>
 
     <packageSources>
-        <add key="Local Repository" value="C:\NugetSource" />
+        <!--<add key="Local Repository" value="C:\NugetSource" />-->
     </packageSources>
 
     <bindingRedirects>

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageRestore>
+        <add key="enabled" value="True" />
+        <add key="automatic" value="True" />
+    </packageRestore>
+
+    <packageSources>
+        <add key="Local Repository" value="C:\NugetSource" />
+    </packageSources>
+
+    <bindingRedirects>
+        <add key="skip" value="False" />
+    </bindingRedirects>
+
+    <packageManagement>
+        <add key="format" value="0" />
+        <add key="disabled" value="False" />
+    </packageManagement>
+</configuration>

--- a/src/CleanArchitecture.Core/CleanArchitecture.Core.csproj
+++ b/src/CleanArchitecture.Core/CleanArchitecture.Core.csproj
@@ -1,17 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.46" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>CleanArchitecture.Core</AssemblyName>
-    <PackageId>CleanArchitecture.Core</PackageId>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ardalis.GuardClauses" Version="1.2.9" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="NETStandard.Library" Version="2.0.3" />
+    <PackageReference Include="Ardalis.GuardClauses" />
   </ItemGroup>
 
 </Project>

--- a/src/CleanArchitecture.Infrastructure/CleanArchitecture.Infrastructure.csproj
+++ b/src/CleanArchitecture.Infrastructure/CleanArchitecture.Infrastructure.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="SQLite" />
+    <PackageReference Include="NETStandard.Library" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/CleanArchitecture.Infrastructure/CleanArchitecture.Infrastructure.csproj
+++ b/src/CleanArchitecture.Infrastructure/CleanArchitecture.Infrastructure.csproj
@@ -1,22 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.46" />
+  
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
-    <AssemblyName>CleanArchitecture.Infrastructure</AssemblyName>
-    <PackageId>CleanArchitecture.Infrastructure</PackageId>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\CleanArchitecture.Core\CleanArchitecture.Core.csproj" />
+    <PackageReference Include="Autofac" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" />
+    <PackageReference Include="Ardalis.EFCore.Extensions" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="SQLite" />
   </ItemGroup>
-
+  
   <ItemGroup>
-    <PackageReference Include="Ardalis.EFCore.Extensions" Version="1.0.1" />
-    <PackageReference Include="Autofac" Version="4.9.3" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.2.6" PrivateAssets="all">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.6" />
-    <PackageReference Include="SQLite" Version="3.13.0" />
+    <ProjectReference Include="..\CleanArchitecture.Core\CleanArchitecture.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/src/CleanArchitecture.Infrastructure/ContainerSetup.cs
+++ b/src/CleanArchitecture.Infrastructure/ContainerSetup.cs
@@ -1,0 +1,32 @@
+﻿using Autofac;
+using Autofac.Extensions.DependencyInjection;
+using CleanArchitecture.Core.SharedKernel;
+using CleanArchitecture.Infrastructure.Data;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Reflection;
+
+namespace CleanArchitecture.Infrastructure
+{
+	public static class ContainerSetup
+	{
+		public static IServiceProvider InitializeWeb(Assembly webAssembly, IServiceCollection services) =>
+			new AutofacServiceProvider(BaseAutofacInitialization(setupAction =>
+			{
+				setupAction.Populate(services);
+				setupAction.RegisterAssemblyTypes(webAssembly).AsImplementedInterfaces();
+			}));
+
+		public static IContainer BaseAutofacInitialization(Action<ContainerBuilder> setupAction = null)
+		{
+			var builder = new ContainerBuilder();
+
+			var coreAssembly = Assembly.GetAssembly(typeof(BaseEntity));
+			var infrastructureAssembly = Assembly.GetAssembly(typeof(EfRepository));
+			builder.RegisterAssemblyTypes(coreAssembly, infrastructureAssembly).AsImplementedInterfaces();
+
+			setupAction?.Invoke(builder);
+			return builder.Build();
+		}
+	}
+}

--- a/src/CleanArchitecture.Infrastructure/StartupSetup.cs
+++ b/src/CleanArchitecture.Infrastructure/StartupSetup.cs
@@ -1,0 +1,13 @@
+﻿using CleanArchitecture.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CleanArchitecture.Infrastructure
+{
+	public static class StartupSetup
+	{
+		public static void AddDbContext(this IServiceCollection services) =>
+			services.AddDbContext<AppDbContext>(options =>
+				options.UseSqlite("Data Source=database.sqlite")); // will be created in web project root
+	}
+}

--- a/src/CleanArchitecture.Web/CleanArchitecture.Web.csproj
+++ b/src/CleanArchitecture.Web/CleanArchitecture.Web.csproj
@@ -1,54 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+  <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.46" />
+  
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>CleanArchitecture.Web</AssemblyName>
     <OutputType>Exe</OutputType>
-    <PackageId>CleanArchitecture.Web</PackageId>
+    <WebProjectMode>true</WebProjectMode>
   </PropertyGroup>
-
+  
   <ItemGroup>
-    <Content Update="wwwroot\**\*;Views\**\*;Areas\**\Views;appsettings.json;web.config">
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Web.LibraryManager.Build" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
   </ItemGroup>
-
+  
   <ItemGroup>
-    <ProjectReference Include="..\CleanArchitecture.Core\CleanArchitecture.Core.csproj" />
     <ProjectReference Include="..\CleanArchitecture.Infrastructure\CleanArchitecture.Infrastructure.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.9.3" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.4.0" />
-    <PackageReference Include="Dapper" Version="1.60.6" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.2.6" PrivateAssets="all">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.3" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.0.76" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
-    <PackageReference Include="SQLite" Version="3.13.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6"/>
-  </ItemGroup>
-
-  <Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">
-    <Exec Command="bower install" />
-    <Exec Command="dotnet bundle" />
-  </Target>
-
-  <ItemGroup>
-    <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.8.391" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Update="Pages\_ViewImports.cshtml">
-      <Pack>$(IncludeRazorContentInPack)</Pack>
-    </Content>
-    <Content Update="Pages\_ViewStart.cshtml">
-      <Pack>$(IncludeRazorContentInPack)</Pack>
-    </Content>
   </ItemGroup>
 
 </Project>

--- a/src/CleanArchitecture.Web/CleanArchitecture.Web.csproj
+++ b/src/CleanArchitecture.Web/CleanArchitecture.Web.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="NETStandard.Library" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/CleanArchitecture.Web/Startup.cs
+++ b/src/CleanArchitecture.Web/Startup.cs
@@ -1,105 +1,64 @@
-﻿using Autofac;
-using Autofac.Extensions.DependencyInjection;
-using CleanArchitecture.Core.SharedKernel;
-using CleanArchitecture.Infrastructure.Data;
+﻿using CleanArchitecture.Infrastructure;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Swashbuckle.AspNetCore.Swagger;
+using Microsoft.OpenApi.Models;
 using System;
 using System.Reflection;
 
 namespace CleanArchitecture.Web
 {
-    public class Startup
-    {
-        public Startup(IConfiguration config)
-        {
-            Configuration = config;
-        }
+	public class Startup
+	{
+		public Startup(IConfiguration config) => this.Configuration = config;
 
-        public IConfiguration Configuration { get; }
+		public IConfiguration Configuration { get; }
 
-        public IServiceProvider ConfigureServices(IServiceCollection services)
-        {
-            services.Configure<CookiePolicyOptions>(options =>
-            {
-                // This lambda determines whether user consent for non-essential cookies is needed for a given request.
-                options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
-            });
-            // TODO: Add DbContext and IOC
-            string dbName = Guid.NewGuid().ToString();
+		public IServiceProvider ConfigureServices(IServiceCollection services)
+		{
+			services.Configure<CookiePolicyOptions>(options =>
+			{
+				options.CheckConsentNeeded = context => true;
+				options.MinimumSameSitePolicy = SameSiteMode.None;
+			});
 
-            services.AddDbContext<AppDbContext>(options =>
-                options.UseSqlite("Data Source=database.sqlite")); // will be created in web project root
-//                options.UseInMemoryDatabase(dbName));
-                //options.UseSqlServer(Configuration.GetConnectionString("DefaultConnection")));
+			services.AddDbContext();
 
-            services.AddMvc()
-                .AddControllersAsServices()
-                .SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+			services.AddMvc(setupAction => setupAction.EnableEndpointRouting = false)
+				.AddControllersAsServices()
+				.SetCompatibilityVersion(CompatibilityVersion.Latest);
 
-            services.AddSwaggerGen(c =>
-            {
-                c.SwaggerDoc("v1", new Info { Title = "My API", Version = "v1" });
-            });
+			services.AddSwaggerGen(c => c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" }));
 
-            return BuildDependencyInjectionProvider(services);
-        }
+			return ContainerSetup.InitializeWeb(Assembly.GetExecutingAssembly(), services);
+		}
 
-        private static IServiceProvider BuildDependencyInjectionProvider(IServiceCollection services)
-        {
-            var builder = new ContainerBuilder();
+		public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+		{
+			if (env.EnvironmentName == "Development")
+			{
+				app.UseDeveloperExceptionPage();
+			}
+			else
+			{
+				app.UseExceptionHandler("/Home/Error");
+				app.UseHsts();
+			}
 
-            // Populate the container using the service collection
-            builder.Populate(services);
+			app.UseHttpsRedirection();
+			app.UseStaticFiles();
+			app.UseCookiePolicy();
 
-            Assembly webAssembly = Assembly.GetExecutingAssembly();
-            Assembly coreAssembly = Assembly.GetAssembly(typeof(BaseEntity));
-            Assembly infrastructureAssembly = Assembly.GetAssembly(typeof(EfRepository)); // TODO: Move to Infrastucture Registry
-            builder.RegisterAssemblyTypes(webAssembly, coreAssembly, infrastructureAssembly).AsImplementedInterfaces();
+			// Enable middleware to serve generated Swagger as a JSON endpoint.
+			app.UseSwagger();
 
-            IContainer applicationContainer = builder.Build();
-            return new AutofacServiceProvider(applicationContainer);
-        }
+			// Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.), specifying the Swagger JSON endpoint.
+			app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1"));
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-        {
-            if (env.IsDevelopment())
-            {
-                app.UseDeveloperExceptionPage();
-            }
-            else
-            {
-                app.UseExceptionHandler("/Home/Error");
-                app.UseHsts();
-            }
-
-            app.UseHttpsRedirection();
-            app.UseStaticFiles();
-            app.UseCookiePolicy();
-
-            // Enable middleware to serve generated Swagger as a JSON endpoint.
-            app.UseSwagger();
-
-            // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.), specifying the Swagger JSON endpoint.
-            app.UseSwaggerUI(c =>
-            {
-                c.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1");
-            });
-
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
-        }
-    }
+			app.UseMvcWithDefaultRoute();
+		}
+	}
 }

--- a/src/CleanArchitecture.Web/Startup.cs
+++ b/src/CleanArchitecture.Web/Startup.cs
@@ -2,7 +2,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
@@ -27,9 +26,8 @@ namespace CleanArchitecture.Web
 
 			services.AddDbContext();
 
-			services.AddMvc(setupAction => setupAction.EnableEndpointRouting = false)
-				.AddControllersAsServices()
-				.SetCompatibilityVersion(CompatibilityVersion.Latest);
+			services.AddControllersWithViews().AddNewtonsoftJson();
+			services.AddRazorPages();
 
 			services.AddSwaggerGen(c => c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" }));
 
@@ -47,6 +45,7 @@ namespace CleanArchitecture.Web
 				app.UseExceptionHandler("/Home/Error");
 				app.UseHsts();
 			}
+			app.UseRouting();
 
 			app.UseHttpsRedirection();
 			app.UseStaticFiles();
@@ -58,7 +57,11 @@ namespace CleanArchitecture.Web
 			// Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.), specifying the Swagger JSON endpoint.
 			app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1"));
 
-			app.UseMvcWithDefaultRoute();
+			app.UseEndpoints(endpoints =>
+			{
+				endpoints.MapDefaultControllerRoute();
+				endpoints.MapRazorPages();
+			});
 		}
 	}
 }

--- a/src/CleanArchitecture.Web/web.config
+++ b/src/CleanArchitecture.Web/web.config
@@ -5,10 +5,12 @@
   -->
   <system.webServer>
     <handlers>
-      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified" />
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
     </handlers>
-    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" startupTimeLimit="3600" requestTimeout="23:00:00">
-      <environmentVariables />
+    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" startupTimeLimit="3600" requestTimeout="23:00:00" hostingModel="InProcess">
+      <environmentVariables>
+        <environmentVariable name="ASPNETCORE_ENVIRONMENT" value="Development" />
+      </environmentVariables>
     </aspNetCore>
   </system.webServer>
 </configuration>

--- a/tests/CleanArchitecture.FunctionalTests/CleanArchitecture.FunctionalTests.csproj
+++ b/tests/CleanArchitecture.FunctionalTests/CleanArchitecture.FunctionalTests.csproj
@@ -1,41 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+  <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.46" />
+  
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
-
-    <IsPackable>false</IsPackable>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TestProjectMode>true</TestProjectMode>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.3.1">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="ReportGenerator" Version="4.2.5" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.2.6" PrivateAssets="all">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Moq" Version="4.12.0" />
-    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\CleanArchitecture.Core\CleanArchitecture.Core.csproj" />
-    <ProjectReference Include="..\..\src\CleanArchitecture.Infrastructure\CleanArchitecture.Infrastructure.csproj" />
-    <ProjectReference Include="..\..\src\CleanArchitecture.Web\CleanArchitecture.Web.csproj" />
     <ProjectReference Include="..\CleanArchitecture.Tests\CleanArchitecture.UnitTests.csproj" />
   </ItemGroup>
 

--- a/tests/CleanArchitecture.IntegrationTests/CleanArchitecture.IntegrationTests.csproj
+++ b/tests/CleanArchitecture.IntegrationTests/CleanArchitecture.IntegrationTests.csproj
@@ -1,41 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.46" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
-
-    <IsPackable>false</IsPackable>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TestProjectMode>true</TestProjectMode>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.3.1">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="ReportGenerator" Version="4.2.5" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.2.6" PrivateAssets="all">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Moq" Version="4.12.0" />
-    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\CleanArchitecture.Core\CleanArchitecture.Core.csproj" />
-    <ProjectReference Include="..\..\src\CleanArchitecture.Infrastructure\CleanArchitecture.Infrastructure.csproj" />
-    <ProjectReference Include="..\..\src\CleanArchitecture.Web\CleanArchitecture.Web.csproj" />
     <ProjectReference Include="..\CleanArchitecture.Tests\CleanArchitecture.UnitTests.csproj" />
   </ItemGroup>
 

--- a/tests/CleanArchitecture.Tests/CleanArchitecture.UnitTests.csproj
+++ b/tests/CleanArchitecture.Tests/CleanArchitecture.UnitTests.csproj
@@ -1,59 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+  <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.46" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
+    <TestProjectMode>true</TestProjectMode>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Update="xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <PackageReference Include="Moq" />
+    <PackageReference Include="ReportGenerator" />
   </ItemGroup>
-  <!-- https://github.com/NuGet/Home/issues/4412. -->
-  <Target Name="CopyDepsFiles" AfterTargets="Build" Condition="'$(TargetFramework)'!=''">
-    <ItemGroup>
-      <DepsFilePaths Include="$([System.IO.Path]::ChangeExtension('%(_ResolvedProjectReferencePaths.FullPath)', '.deps.json'))" />
-    </ItemGroup>
-
-    <Copy SourceFiles="%(DepsFilePaths.FullPath)" DestinationFolder="$(OutputPath)" Condition="Exists('%(DepsFilePaths.FullPath)')" />
-  </Target>
-
+  
   <ItemGroup>
-    <ProjectReference Include="..\..\src\CleanArchitecture.Core\CleanArchitecture.Core.csproj" />
-    <ProjectReference Include="..\..\src\CleanArchitecture.Infrastructure\CleanArchitecture.Infrastructure.csproj" />
     <ProjectReference Include="..\..\src\CleanArchitecture.Web\CleanArchitecture.Web.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.3.1">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="ReportGenerator" Version="4.2.5" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.2.6" PrivateAssets="all">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Moq" Version="4.12.0" />
-    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Changesets:
- .NET Core 3.0
- Moved csproj's targets, properties, references into Directory.Build.targets, Directory.Build.props and Packages.props - one configuration, many projects
- Moved container and startup initialization into Infrastructure.

Directory.Build.Targets manage targets that's we want to define inside csproj's.

Directory.Build.props manage common properties that can be shared across projects.

Packages.props defines a list of packages and it's versions - version changed inside this file will change all references. You cannot add package inside a project without definition in Packages.props.

This change introduces the deterministic approach to build applications. Projects should be clean, stupid. More generic abstractions like solutions or build system should know how to deploy a project.

Everything base on the project [Jarvis](https://github.com/Xeinaemm/Jarvis). This approach working at my client's systems that deploying more than 50 systems parallelly. Azure DevOps invoke orchestrator(Cake) that know how to deploy systems.

In DeploymentSettings.props I added an example of custom flag **DeployNugetPackages** that deploy packages automatically into the local repository(C:\NugetSource - windows based directory) that use nuget.config. I turned off this approach at this moment because NuGet is greedy and without valid source will fail(no folder, Linux, etc.). This approach gives the fast development of packages because they are available after the build.

I wanted to split web with infrastructure and core because it's possible with this approach and will give deterministic result but we are using DTOs inside web so I abandoned this approach at this moment.
