### PR TITLE
Completed correcting namespace in SharedKernel

### DIFF
--- a/src/CleanArchitecture.Core/Entities/ToDoItem.cs
+++ b/src/CleanArchitecture.Core/Entities/ToDoItem.cs
@@ -1,5 +1,5 @@
 ﻿using CleanArchitecture.Core.Events;
-using CleanArchitecture.Core.SharedKernel;
+using CleanArchitecture.SharedKernel;
 
 namespace CleanArchitecture.Core.Entities
 {

--- a/src/CleanArchitecture.Core/Events/ToDoItemCompletedEvent.cs
+++ b/src/CleanArchitecture.Core/Events/ToDoItemCompletedEvent.cs
@@ -1,5 +1,5 @@
 ﻿using CleanArchitecture.Core.Entities;
-using CleanArchitecture.Core.SharedKernel;
+using CleanArchitecture.SharedKernel;
 
 namespace CleanArchitecture.Core.Events
 {

--- a/src/CleanArchitecture.Infrastructure/Data/AppDbContext.cs
+++ b/src/CleanArchitecture.Infrastructure/Data/AppDbContext.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using CleanArchitecture.Core.Entities;
-using CleanArchitecture.Core.SharedKernel;
+using CleanArchitecture.SharedKernel;
 using Ardalis.EFCore.Extensions;
 using System.Reflection;
 using JetBrains.Annotations;

--- a/src/CleanArchitecture.Infrastructure/Data/EfRepository.cs
+++ b/src/CleanArchitecture.Infrastructure/Data/EfRepository.cs
@@ -1,5 +1,5 @@
 ﻿using CleanArchitecture.SharedKernel.Interfaces;
-using CleanArchitecture.Core.SharedKernel;
+using CleanArchitecture.SharedKernel;
 using Microsoft.EntityFrameworkCore;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/CleanArchitecture.Infrastructure/DomainEvents/DomainEventDispatcher.cs
+++ b/src/CleanArchitecture.Infrastructure/DomainEvents/DomainEventDispatcher.cs
@@ -1,6 +1,6 @@
 ﻿using Autofac;
 using CleanArchitecture.SharedKernel.Interfaces;
-using CleanArchitecture.Core.SharedKernel;
+using CleanArchitecture.SharedKernel;
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/CleanArchitecture.SharedKernel/BaseDomainEvent.cs
+++ b/src/CleanArchitecture.SharedKernel/BaseDomainEvent.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace CleanArchitecture.Core.SharedKernel
+namespace CleanArchitecture.SharedKernel
 {
     public abstract class BaseDomainEvent
     {

--- a/src/CleanArchitecture.SharedKernel/BaseEntity.cs
+++ b/src/CleanArchitecture.SharedKernel/BaseEntity.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace CleanArchitecture.Core.SharedKernel
+namespace CleanArchitecture.SharedKernel
 {
     // This can be modified to BaseEntity<TId> to support multiple key types (e.g. Guid)
     public abstract class BaseEntity

--- a/src/CleanArchitecture.SharedKernel/IgnoreMemberAttribute.cs
+++ b/src/CleanArchitecture.SharedKernel/IgnoreMemberAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace CleanArchitecture.Core.SharedKernel
+namespace CleanArchitecture.SharedKernel
 {
     // source: https://github.com/jhewlett/ValueObject
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]

--- a/src/CleanArchitecture.SharedKernel/Interfaces/IDomainEventDispatcher.cs
+++ b/src/CleanArchitecture.SharedKernel/Interfaces/IDomainEventDispatcher.cs
@@ -1,5 +1,5 @@
 ﻿using System.Threading.Tasks;
-using CleanArchitecture.Core.SharedKernel;
+using CleanArchitecture.SharedKernel;
 
 namespace CleanArchitecture.SharedKernel.Interfaces
 {

--- a/src/CleanArchitecture.SharedKernel/Interfaces/IHandle.cs
+++ b/src/CleanArchitecture.SharedKernel/Interfaces/IHandle.cs
@@ -1,5 +1,5 @@
 ﻿using System.Threading.Tasks;
-using CleanArchitecture.Core.SharedKernel;
+using CleanArchitecture.SharedKernel;
 
 namespace CleanArchitecture.SharedKernel.Interfaces
 {

--- a/src/CleanArchitecture.SharedKernel/Interfaces/IRepository.cs
+++ b/src/CleanArchitecture.SharedKernel/Interfaces/IRepository.cs
@@ -1,5 +1,4 @@
-﻿using CleanArchitecture.Core.SharedKernel;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace CleanArchitecture.SharedKernel.Interfaces
 {

--- a/src/CleanArchitecture.SharedKernel/ValueObject.cs
+++ b/src/CleanArchitecture.SharedKernel/ValueObject.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 
 
 
-namespace CleanArchitecture.Core.SharedKernel
+namespace CleanArchitecture.SharedKernel
 {
     // source: https://github.com/jhewlett/ValueObject
     public abstract class ValueObject : IEquatable<ValueObject>

--- a/tests/CleanArchitecture.Tests/NoOpDomainEventDispatcher.cs
+++ b/tests/CleanArchitecture.Tests/NoOpDomainEventDispatcher.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 using CleanArchitecture.SharedKernel.Interfaces;
-using CleanArchitecture.Core.SharedKernel;
+using CleanArchitecture.SharedKernel;
 
 namespace CleanArchitecture.UnitTests
 {


### PR DESCRIPTION
Fixes #93 

I corrected the namespace in the classes in SharedKernel. They contained "Core" which was incorrect.

Tests passed before and after.