### PR TITLE
Adjusted DatabasePopulator to check for 3 or more TodoItems instead of 5

### DIFF
--- a/src/CleanArchitecture.Core/DatabasePopulator.cs
+++ b/src/CleanArchitecture.Core/DatabasePopulator.cs
@@ -8,7 +8,7 @@ namespace CleanArchitecture.Core
     {
         public static int PopulateDatabase(IRepository todoRepository)
         {
-            if (todoRepository.List<ToDoItem>().Count() >= 5) return 0;
+            if (todoRepository.List<ToDoItem>().Count() >= 3) return 0;
 
             todoRepository.Add(new ToDoItem
             {


### PR DESCRIPTION
Before adding the 3 default ToDo Items, Database populator is checking if the count of the existing TodoItems is greater than or equal to 5. This can cause 2 sets of the same 3 todo items to be added if you call it more than once. This PR makes it check the count for >=3.