### PR TITLE
Fix tests seeding database twice

### DIFF
--- a/src/Clean.Architecture.Web/SeedData.cs
+++ b/src/Clean.Architecture.Web/SeedData.cs
@@ -41,13 +41,16 @@ public static class SeedData
   }
   public static void PopulateTestData(AppDbContext dbContext)
   {
+    foreach (var item in dbContext.Projects)
+    {
+      dbContext.Remove(item);
+    }
     foreach (var item in dbContext.ToDoItems)
     {
       dbContext.Remove(item);
     }
     dbContext.SaveChanges();
 
-    TestProject1.Id = 1;
     TestProject1.AddItem(ToDoItem1);
     TestProject1.AddItem(ToDoItem2);
     TestProject1.AddItem(ToDoItem3);

--- a/tests/Clean.Architecture.FunctionalTests/CustomWebApplicationFactory.cs
+++ b/tests/Clean.Architecture.FunctionalTests/CustomWebApplicationFactory.cs
@@ -23,7 +23,7 @@ public class CustomWebApplicationFactory<TStartup> : WebApplicationFactory<TStar
   protected override IHost CreateHost(IHostBuilder builder)
   {
     var host = builder.Build();
-    builder.ConfigureWebHost(ConfigureWebHost);
+    host.Start();
 
     // Get service provider.
     var serviceProvider = host.Services;
@@ -43,8 +43,12 @@ public class CustomWebApplicationFactory<TStartup> : WebApplicationFactory<TStar
 
       try
       {
+        // Can also skip creating the items
+        //if (!db.ToDoItems.Any())
+        //{
         // Seed the database with test data.
-        SeedData.PopulateTestData(db);
+          SeedData.PopulateTestData(db);
+        //}
       }
       catch (Exception ex)
       {
@@ -53,7 +57,6 @@ public class CustomWebApplicationFactory<TStartup> : WebApplicationFactory<TStar
       }
     }
 
-    host.Start();
     return host;
   }
 


### PR DESCRIPTION
This fixes the outstanding issue of the tests seeding twice. The reason was that DeferredHostBuilder actually already starts the host in the background when calling builder.Build(). This leads to a race condition. 

Fixed by starting the host explicitly.