### PR TITLE
fix  'NoOpMediator' does not implement interface member

### DIFF
--- a/tests/Clean.Architecture.UnitTests/NoOpMediator.cs
+++ b/tests/Clean.Architecture.UnitTests/NoOpMediator.cs
@@ -1,4 +1,5 @@
-﻿using MediatR;
+﻿using System.Runtime.CompilerServices;
+using MediatR;
 
 namespace Clean.Architecture.UnitTests;
 
@@ -22,5 +23,19 @@ public class NoOpMediator : IMediator
   public Task<object?> Send(object request, CancellationToken cancellationToken = default)
   {
     return Task.FromResult<object?>(default);
+  }
+
+  public async IAsyncEnumerable<TResponse> CreateStream<TResponse>(IStreamRequest<TResponse> request,
+    [EnumeratorCancellation] CancellationToken cancellationToken = default)
+  {
+    await Task.CompletedTask;
+    yield break;
+  }
+
+  public async IAsyncEnumerable<object?> CreateStream(object request,
+    [EnumeratorCancellation] CancellationToken cancellationToken = default)
+  {
+    await Task.CompletedTask;
+    yield break;
   }
 }


### PR DESCRIPTION
I have two compilation errors:
```
  NoOpMediator.cs(5, 29): [CS0535] 'NoOpMediator' does not implement interface member 'ISender.CreateStream<TResponse>(IStreamRequest<TResponse>, CancellationToken)'
  NoOpMediator.cs(5, 29): [CS0535] 'NoOpMediator' does not implement interface member 'ISender.CreateStream(object, CancellationToken)'
```
I use workaround from https://github.com/dotnet/runtime/issues/1128