### PR TITLE
Add Smart Enum with example

### DIFF
--- a/src/Clean.Architecture.Core/Clean.Architecture.Core.csproj
+++ b/src/Clean.Architecture.Core/Clean.Architecture.Core.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.0" />
     <PackageReference Include="Ardalis.Result" Version="3.1.2" />
+    <PackageReference Include="Ardalis.SmartEnum" Version="2.0.1" />
     <PackageReference Include="Ardalis.Specification" Version="6.0.0" />
     <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="MediatR" Version="10.0.1" />

--- a/src/Clean.Architecture.Core/ProjectAggregate/PriorityStatus.cs
+++ b/src/Clean.Architecture.Core/ProjectAggregate/PriorityStatus.cs
@@ -1,0 +1,11 @@
+﻿using Ardalis.SmartEnum;
+
+namespace Clean.Architecture.Core.ProjectAggregate;
+public class PriorityStatus : SmartEnum<PriorityStatus>
+{
+  public static readonly PriorityStatus Backlog = new(nameof(Backlog), 0);
+  public static readonly PriorityStatus Critical = new(nameof(Critical), 1);
+
+  protected PriorityStatus(string name, int value) : base(name, value) { }
+}
+

--- a/src/Clean.Architecture.Core/ProjectAggregate/PriorityStatus.cs
+++ b/src/Clean.Architecture.Core/ProjectAggregate/PriorityStatus.cs
@@ -1,6 +1,7 @@
 ﻿using Ardalis.SmartEnum;
 
 namespace Clean.Architecture.Core.ProjectAggregate;
+
 public class PriorityStatus : SmartEnum<PriorityStatus>
 {
   public static readonly PriorityStatus Backlog = new(nameof(Backlog), 0);

--- a/src/Clean.Architecture.Core/ProjectAggregate/Project.cs
+++ b/src/Clean.Architecture.Core/ProjectAggregate/Project.cs
@@ -13,9 +13,12 @@ public class Project : BaseEntity, IAggregateRoot
   public IEnumerable<ToDoItem> Items => _items.AsReadOnly();
   public ProjectStatus Status => _items.All(i => i.IsDone) ? ProjectStatus.Complete : ProjectStatus.InProgress;
 
-  public Project(string name)
+  public PriorityStatus Priority { get; }
+
+  public Project(string name, PriorityStatus priority)
   {
     Name = Guard.Against.NullOrEmpty(name, nameof(name));
+    Priority = priority;
   }
 
   public void AddItem(ToDoItem newItem)

--- a/src/Clean.Architecture.Infrastructure/Data/Config/ProjectConfiguration.cs
+++ b/src/Clean.Architecture.Infrastructure/Data/Config/ProjectConfiguration.cs
@@ -11,5 +11,10 @@ public class ProjectConfiguration : IEntityTypeConfiguration<Project>
     builder.Property(p => p.Name)
         .HasMaxLength(100)
         .IsRequired();
+
+    builder.Property(p => p.Priority)
+      .HasConversion(
+          p => p.Value,
+          p => PriorityStatus.FromValue(p));
   }
 }

--- a/src/Clean.Architecture.Web/Api/ProjectsController.cs
+++ b/src/Clean.Architecture.Web/Api/ProjectsController.cs
@@ -62,7 +62,7 @@ public class ProjectsController : BaseApiController
   [HttpPost]
   public async Task<IActionResult> Post([FromBody] CreateProjectDTO request)
   {
-    var newProject = new Project(request.Name);
+    var newProject = new Project(request.Name, PriorityStatus.Backlog);
 
     var createdProject = await _repository.AddAsync(newProject);
 

--- a/src/Clean.Architecture.Web/Endpoints/ProjectEndpoints/Create.cs
+++ b/src/Clean.Architecture.Web/Endpoints/ProjectEndpoints/Create.cs
@@ -32,7 +32,7 @@ public class Create : EndpointBaseAsync
       return BadRequest();
     }
 
-    var newProject = new Project(request.Name);
+    var newProject = new Project(request.Name, PriorityStatus.Backlog);
 
     var createdItem = await _repository.AddAsync(newProject); // TODO: pass cancellation token
 

--- a/src/Clean.Architecture.Web/SeedData.cs
+++ b/src/Clean.Architecture.Web/SeedData.cs
@@ -6,7 +6,7 @@ namespace Clean.Architecture.Web;
 
 public static class SeedData
 {
-  public static readonly Project TestProject1 = new Project("Test Project");
+  public static readonly Project TestProject1 = new Project("Test Project", PriorityStatus.Backlog);
   public static readonly ToDoItem ToDoItem1 = new ToDoItem
   {
     Title = "Get Sample Working",

--- a/tests/Clean.Architecture.IntegrationTests/Data/EfRepositoryAdd.cs
+++ b/tests/Clean.Architecture.IntegrationTests/Data/EfRepositoryAdd.cs
@@ -9,8 +9,9 @@ public class EfRepositoryAdd : BaseEfRepoTestFixture
   public async Task AddsProjectAndSetsId()
   {
     var testProjectName = "testProject";
+    var testProjectStatus = PriorityStatus.Backlog;
     var repository = GetRepository();
-    var project = new Project(testProjectName);
+    var project = new Project(testProjectName, testProjectStatus);
 
     await repository.AddAsync(project);
 
@@ -18,6 +19,7 @@ public class EfRepositoryAdd : BaseEfRepoTestFixture
                     .FirstOrDefault();
 
     Assert.Equal(testProjectName, newProject?.Name);
+    Assert.Equal(testProjectStatus, newProject?.Priority);
     Assert.True(newProject?.Id > 0);
   }
 }

--- a/tests/Clean.Architecture.IntegrationTests/Data/EfRepositoryDelete.cs
+++ b/tests/Clean.Architecture.IntegrationTests/Data/EfRepositoryDelete.cs
@@ -11,7 +11,7 @@ public class EfRepositoryDelete : BaseEfRepoTestFixture
     // add a project
     var repository = GetRepository();
     var initialName = Guid.NewGuid().ToString();
-    var project = new Project(initialName);
+    var project = new Project(initialName, PriorityStatus.Backlog);
     await repository.AddAsync(project);
 
     // delete the item

--- a/tests/Clean.Architecture.IntegrationTests/Data/EfRepositoryUpdate.cs
+++ b/tests/Clean.Architecture.IntegrationTests/Data/EfRepositoryUpdate.cs
@@ -12,7 +12,7 @@ public class EfRepositoryUpdate : BaseEfRepoTestFixture
     // add a project
     var repository = GetRepository();
     var initialName = Guid.NewGuid().ToString();
-    var project = new Project(initialName);
+    var project = new Project(initialName, PriorityStatus.Backlog);
 
     await repository.AddAsync(project);
 
@@ -40,6 +40,7 @@ public class EfRepositoryUpdate : BaseEfRepoTestFixture
 
     Assert.NotNull(updatedItem);
     Assert.NotEqual(project.Name, updatedItem?.Name);
+    Assert.Equal(project.Priority, updatedItem?.Priority);
     Assert.Equal(newProject.Id, updatedItem?.Id);
   }
 }

--- a/tests/Clean.Architecture.UnitTests/Core/ProjectAggregate/ProjectConstructor.cs
+++ b/tests/Clean.Architecture.UnitTests/Core/ProjectAggregate/ProjectConstructor.cs
@@ -6,11 +6,12 @@ namespace Clean.Architecture.UnitTests.Core.ProjectAggregate;
 public class ProjectConstructor
 {
   private string _testName = "test name";
+  private PriorityStatus _testPriority = PriorityStatus.Backlog;
   private Project? _testProject;
 
   private Project CreateProject()
   {
-    return new Project(_testName);
+    return new Project(_testName, _testPriority);
   }
 
   [Fact]
@@ -19,6 +20,14 @@ public class ProjectConstructor
     _testProject = CreateProject();
 
     Assert.Equal(_testName, _testProject.Name);
+  }
+
+  [Fact]
+  public void InitializesPriority()
+  {
+    _testProject = CreateProject();
+
+    Assert.Equal(_testPriority, _testProject.Priority);
   }
 
   [Fact]

--- a/tests/Clean.Architecture.UnitTests/Core/ProjectAggregate/Project_AddItem.cs
+++ b/tests/Clean.Architecture.UnitTests/Core/ProjectAggregate/Project_AddItem.cs
@@ -5,7 +5,7 @@ namespace Clean.Architecture.UnitTests.Core.ProjectAggregate;
 
 public class Project_AddItem
 {
-  private Project _testProject = new Project("some name");
+  private Project _testProject = new Project("some name", PriorityStatus.Backlog);
 
   [Fact]
   public void AddsItemToItems()


### PR DESCRIPTION
Add reference to Ardalis.SmartEnum. 
Demonstrates Smart Enum on the Project entity and persisting values with Entity Framework Core value converters. 