### PR TITLE
Remove unneeded library

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,6 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.5" />
     <PackageVersion Include="Moq" Version="4.18.1" />
-    <PackageVersion Include="NETStandard.Library" Version="2.0.3" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="ReportGenerator" Version="5.1.9" />
     <PackageVersion Include="Serilog.AspNetCore" Version="5.0.0" />

--- a/src/Clean.Architecture.Infrastructure/Clean.Architecture.Infrastructure.csproj
+++ b/src/Clean.Architecture.Infrastructure/Clean.Architecture.Infrastructure.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="SQLite" />
-    <PackageReference Include="NETStandard.Library" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Clean.Architecture.Web/Clean.Architecture.Web.csproj
+++ b/src/Clean.Architecture.Web/Clean.Architecture.Web.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
     <PackageReference Include="Serilog.AspNetCore" />
-    <PackageReference Include="NETStandard.Library" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" />
   </ItemGroup>
   


### PR DESCRIPTION
`NETStandard.Library` was only needed by `netstandard` projects, before SDK style projects came about.

See 
https://stackoverflow.com/questions/46904973/what-projects-need-to-reference-the-net-standard-library-in-a-cross-platform-so and
https://github.com/dotnet/sdk/blob/3b684c6ff1464a1b5fa026542e096f74f2ed33a0/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets#L44-L55

I've also removed it and run the project with no issues.