### PR TITLE
Updated calls to methods in HttpClientTestExtensions using Async suffix.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="Ardalis.ApiEndpoints" Version="4.0.1" />
     <PackageVersion Include="Ardalis.GuardClauses" Version="4.0.1" />
-    <PackageVersion Include="Ardalis.HttpClientTestExtensions" Version="1.0.0" />
+    <PackageVersion Include="Ardalis.HttpClientTestExtensions" Version="2.0.1" />
     <PackageVersion Include="Ardalis.ListStartupServices" Version="1.1.4" />
     <PackageVersion Include="Ardalis.Result" Version="4.0.0" />
     <PackageVersion Include="Ardalis.Result.AspNetCore" Version="4.0.0" />

--- a/tests/Clean.Architecture.FunctionalTests/ApiEndpoints/ProjectGetById.cs
+++ b/tests/Clean.Architecture.FunctionalTests/ApiEndpoints/ProjectGetById.cs
@@ -18,7 +18,7 @@ public class ProjectGetById : IClassFixture<CustomWebApplicationFactory<WebMarke
   [Fact]
   public async Task ReturnsSeedProjectGivenId1()
   {
-    var result = await _client.GetAndDeserialize<GetProjectByIdResponse>(GetProjectByIdRequest.BuildRoute(1));
+    var result = await _client.GetAndDeserializeAsync<GetProjectByIdResponse>(GetProjectByIdRequest.BuildRoute(1));
 
     Assert.Equal(1, result.Id);
     Assert.Equal(SeedData.TestProject1.Name, result.Name);
@@ -29,6 +29,6 @@ public class ProjectGetById : IClassFixture<CustomWebApplicationFactory<WebMarke
   public async Task ReturnsNotFoundGivenId0()
   {
     string route = GetProjectByIdRequest.BuildRoute(0);
-    _ = await _client.GetAndEnsureNotFound(route);
+    _ = await _client.GetAndEnsureNotFoundAsync(route);
   }
 }

--- a/tests/Clean.Architecture.FunctionalTests/ApiEndpoints/ProjectList.cs
+++ b/tests/Clean.Architecture.FunctionalTests/ApiEndpoints/ProjectList.cs
@@ -18,7 +18,7 @@ public class ProjectList : IClassFixture<CustomWebApplicationFactory<WebMarker>>
   [Fact]
   public async Task ReturnsOneProject()
   {
-    var result = await _client.GetAndDeserialize<ProjectListResponse>("/Projects");
+    var result = await _client.GetAndDeserializeAsync<ProjectListResponse>("/Projects");
 
     Assert.Single(result.Projects);
     Assert.Contains(result.Projects, i => i.Name == SeedData.TestProject1.Name);

--- a/tests/Clean.Architecture.FunctionalTests/ControllerApis/ApiProjectsControllerList.cs
+++ b/tests/Clean.Architecture.FunctionalTests/ControllerApis/ApiProjectsControllerList.cs
@@ -18,7 +18,7 @@ public class ProjectCreate : IClassFixture<CustomWebApplicationFactory<WebMarker
   [Fact]
   public async Task ReturnsOneProject()
   {
-    var result = await _client.GetAndDeserialize<IEnumerable<ProjectDTO>>("/api/projects");
+    var result = await _client.GetAndDeserializeAsync<IEnumerable<ProjectDTO>>("/api/projects");
 
     Assert.Single(result);
     Assert.Contains(result, i => i.Name == SeedData.TestProject1.Name);


### PR DESCRIPTION
The methods are renamed in Ardalis.HttpCLientTestExtensions resulting in compiling errors when bumping dependency. I renamed the method calls.