### PR TITLE
Remove the WebMaker class in favor of a partial Program class

### DIFF
--- a/src/Clean.Architecture.Web/Api/MetaController.cs
+++ b/src/Clean.Architecture.Web/Api/MetaController.cs
@@ -12,7 +12,7 @@ public class MetaController : BaseApiController
   [HttpGet("/info")]
   public ActionResult<string> Info()
   {
-    var assembly = typeof(WebMarker).Assembly;
+    var assembly = typeof(Program).Assembly;
 
     var creationDate = System.IO.File.GetCreationTime(assembly.Location);
     var version = FileVersionInfo.GetVersionInfo(assembly.Location).ProductVersion;

--- a/src/Clean.Architecture.Web/Program.cs
+++ b/src/Clean.Architecture.Web/Program.cs
@@ -104,3 +104,8 @@ using (var scope = app.Services.CreateScope())
 }
 
 app.Run();
+
+// Make the implicit Program.cs class public, so integration tests can reference the correct assembly for host building
+public partial class Program
+{
+}

--- a/src/Clean.Architecture.Web/WebMarker.cs
+++ b/src/Clean.Architecture.Web/WebMarker.cs
@@ -1,7 +1,0 @@
-﻿namespace Clean.Architecture.Web;
-
-// This is a simple marker class that is used by the integration tests to reference the correct assembly for host building
-public class WebMarker
-{
-
-}

--- a/tests/Clean.Architecture.FunctionalTests/ApiEndpoints/ContributorGetById.cs
+++ b/tests/Clean.Architecture.FunctionalTests/ApiEndpoints/ContributorGetById.cs
@@ -6,11 +6,11 @@ using Xunit;
 namespace Clean.Architecture.FunctionalTests.ApiEndpoints;
 
 [Collection("Sequential")]
-public class ContributorGetById : IClassFixture<CustomWebApplicationFactory<WebMarker>>
+public class ContributorGetById : IClassFixture<CustomWebApplicationFactory<Program>>
 {
   private readonly HttpClient _client;
 
-  public ContributorGetById(CustomWebApplicationFactory<WebMarker> factory)
+  public ContributorGetById(CustomWebApplicationFactory<Program> factory)
   {
     _client = factory.CreateClient();
   }

--- a/tests/Clean.Architecture.FunctionalTests/ApiEndpoints/ContributorList.cs
+++ b/tests/Clean.Architecture.FunctionalTests/ApiEndpoints/ContributorList.cs
@@ -6,11 +6,11 @@ using Xunit;
 namespace Clean.Architecture.FunctionalTests.ApiEndpoints;
 
 [Collection("Sequential")]
-public class ContributorList : IClassFixture<CustomWebApplicationFactory<WebMarker>>
+public class ContributorList : IClassFixture<CustomWebApplicationFactory<Program>>
 {
   private readonly HttpClient _client;
 
-  public ContributorList(CustomWebApplicationFactory<WebMarker> factory)
+  public ContributorList(CustomWebApplicationFactory<Program> factory)
   {
     _client = factory.CreateClient();
   }

--- a/tests/Clean.Architecture.FunctionalTests/ApiEndpoints/ProjectGetById.cs
+++ b/tests/Clean.Architecture.FunctionalTests/ApiEndpoints/ProjectGetById.cs
@@ -6,11 +6,11 @@ using Xunit;
 namespace Clean.Architecture.FunctionalTests.ApiEndpoints;
 
 [Collection("Sequential")]
-public class ProjectGetById : IClassFixture<CustomWebApplicationFactory<WebMarker>>
+public class ProjectGetById : IClassFixture<CustomWebApplicationFactory<Program>>
 {
   private readonly HttpClient _client;
 
-  public ProjectGetById(CustomWebApplicationFactory<WebMarker> factory)
+  public ProjectGetById(CustomWebApplicationFactory<Program> factory)
   {
     _client = factory.CreateClient();
   }

--- a/tests/Clean.Architecture.FunctionalTests/ApiEndpoints/ProjectList.cs
+++ b/tests/Clean.Architecture.FunctionalTests/ApiEndpoints/ProjectList.cs
@@ -6,11 +6,11 @@ using Xunit;
 namespace Clean.Architecture.FunctionalTests.ApiEndpoints;
 
 [Collection("Sequential")]
-public class ProjectList : IClassFixture<CustomWebApplicationFactory<WebMarker>>
+public class ProjectList : IClassFixture<CustomWebApplicationFactory<Program>>
 {
   private readonly HttpClient _client;
 
-  public ProjectList(CustomWebApplicationFactory<WebMarker> factory)
+  public ProjectList(CustomWebApplicationFactory<Program> factory)
   {
     _client = factory.CreateClient();
   }

--- a/tests/Clean.Architecture.FunctionalTests/ControllerApis/ApiProjectsControllerList.cs
+++ b/tests/Clean.Architecture.FunctionalTests/ControllerApis/ApiProjectsControllerList.cs
@@ -6,11 +6,11 @@ using Xunit;
 namespace Clean.Architecture.FunctionalTests.ControllerApis;
 
 [Collection("Sequential")]
-public class ProjectCreate : IClassFixture<CustomWebApplicationFactory<WebMarker>>
+public class ProjectCreate : IClassFixture<CustomWebApplicationFactory<Program>>
 {
   private readonly HttpClient _client;
 
-  public ProjectCreate(CustomWebApplicationFactory<WebMarker> factory)
+  public ProjectCreate(CustomWebApplicationFactory<Program> factory)
   {
     _client = factory.CreateClient();
   }

--- a/tests/Clean.Architecture.FunctionalTests/ControllerApis/MetaControllerInfo.cs
+++ b/tests/Clean.Architecture.FunctionalTests/ControllerApis/MetaControllerInfo.cs
@@ -4,11 +4,11 @@ using Xunit;
 namespace Clean.Architecture.FunctionalTests.ControllerApis;
 
 [Collection("Sequential")]
-public class MetaControllerInfo : IClassFixture<CustomWebApplicationFactory<WebMarker>>
+public class MetaControllerInfo : IClassFixture<CustomWebApplicationFactory<Program>>
 {
   private readonly HttpClient _client;
 
-  public MetaControllerInfo(CustomWebApplicationFactory<WebMarker> factory)
+  public MetaControllerInfo(CustomWebApplicationFactory<Program> factory)
   {
     _client = factory.CreateClient();
   }

--- a/tests/Clean.Architecture.FunctionalTests/ControllerApis/ProjectItemMarkComplete.cs
+++ b/tests/Clean.Architecture.FunctionalTests/ControllerApis/ProjectItemMarkComplete.cs
@@ -6,11 +6,11 @@ using Xunit;
 namespace Clean.Architecture.FunctionalTests.ControllerApis;
 
 [Collection("Sequential")]
-public class ProjectItemMarkComplete : IClassFixture<CustomWebApplicationFactory<WebMarker>>
+public class ProjectItemMarkComplete : IClassFixture<CustomWebApplicationFactory<Program>>
 {
   private readonly HttpClient _client;
 
-  public ProjectItemMarkComplete(CustomWebApplicationFactory<WebMarker> factory)
+  public ProjectItemMarkComplete(CustomWebApplicationFactory<Program> factory)
   {
     _client = factory.CreateClient();
   }

--- a/tests/Clean.Architecture.FunctionalTests/ControllerViews/HomeControllerIndex.cs
+++ b/tests/Clean.Architecture.FunctionalTests/ControllerViews/HomeControllerIndex.cs
@@ -4,11 +4,11 @@ using Xunit;
 namespace Clean.Architecture.FunctionalTests.ControllerViews;
 
 [Collection("Sequential")]
-public class HomeControllerIndex : IClassFixture<CustomWebApplicationFactory<WebMarker>>
+public class HomeControllerIndex : IClassFixture<CustomWebApplicationFactory<Program>>
 {
   private readonly HttpClient _client;
 
-  public HomeControllerIndex(CustomWebApplicationFactory<WebMarker> factory)
+  public HomeControllerIndex(CustomWebApplicationFactory<Program> factory)
   {
     _client = factory.CreateClient();
   }

--- a/tests/Clean.Architecture.FunctionalTests/CustomWebApplicationFactory.cs
+++ b/tests/Clean.Architecture.FunctionalTests/CustomWebApplicationFactory.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Clean.Architecture.FunctionalTests;
 
-public class CustomWebApplicationFactory<TStartup> : WebApplicationFactory<TStartup> where TStartup : class
+public class CustomWebApplicationFactory<TProgram> : WebApplicationFactory<TProgram> where TProgram : class
 {
   /// <summary>
   /// Overriding CreateHost to avoid creating a separate ServiceProvider per this thread:
@@ -34,7 +34,7 @@ public class CustomWebApplicationFactory<TStartup> : WebApplicationFactory<TStar
       var db = scopedServices.GetRequiredService<AppDbContext>();
 
       var logger = scopedServices
-          .GetRequiredService<ILogger<CustomWebApplicationFactory<TStartup>>>();
+          .GetRequiredService<ILogger<CustomWebApplicationFactory<TProgram>>>();
 
       // Ensure the database is created.
       db.Database.EnsureCreated();


### PR DESCRIPTION
**BENEFITS:** 
 - We remove the WebMaker class which will lower the cognitive load for new users of the repo.  
_WebMaker sounds like it's something important and not purely an assembly reference_  

- We move away from TStartup in favor of TProgram
_.NET have moved away from the Startup class as a concept and now we can align the codebase with that ideology.  Also improves the usability for developers who started using .NET in more recent versions,  after Startup.cs was scrapped. (would reduce any questions as to why is this called TStartup, for which you have to go down the history annals of .NET)_

 