### PR TITLE
Packages Updates and Project Configuration Cleanup

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -14,9 +14,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '8.0.100-rc.2.23502.2'
+        dotnet-version: '8.0.100'
     - name: Build with dotnet
       run: dotnet build --configuration Release
     - name: Test with dotnet

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <PropertyGroup>
     <NoWarn>1591</NoWarn> <!-- Remove this to turn on warnings for missing XML Comments -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,11 +1,11 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="Ardalis.GuardClauses" Version="4.1.1" />
+    <PackageVersion Include="Ardalis.GuardClauses" Version="4.2.0" />
     <PackageVersion Include="Ardalis.HttpClientTestExtensions" Version="4.2.0" />
     <PackageVersion Include="Ardalis.ListStartupServices" Version="1.1.4" />
     <PackageVersion Include="Ardalis.Result" Version="7.2.0" />
     <PackageVersion Include="Ardalis.Result.AspNetCore" Version="7.2.0" />
-    <PackageVersion Include="Ardalis.SharedKernel" Version="1.3.0" />
+    <PackageVersion Include="Ardalis.SharedKernel" Version="1.4.0" />
     <PackageVersion Include="Ardalis.SmartEnum" Version="7.0.0" />
     <PackageVersion Include="Ardalis.Specification" Version="7.0.0" />
     <PackageVersion Include="Ardalis.Specification.EntityFrameworkCore" Version="7.0.0" />
@@ -17,9 +17,8 @@
     <PackageVersion Include="FastEndpoints.Swagger" Version="5.19.0" />
     <PackageVersion Include="FastEndpoints.Swagger.Swashbuckle" Version="2.2.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="MailKit" Version="4.2.0" />
+    <PackageVersion Include="MailKit" Version="4.3.0" />
     <PackageVersion Include="MediatR" Version="12.1.1" />
-    <PackageVersion Include="MediatR.Extensions.Autofac.DependencyInjection" Version="11.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.0-rc.2.23480.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-rc.2.23480.2" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-rc.2.23480.1" />
@@ -30,15 +29,14 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-rc.2.23479.6" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.0-rc.2.23509.1" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
-    <PackageVersion Include="ReportGenerator" Version="5.1.26" />
+    <PackageVersion Include="ReportGenerator" Version="5.2.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageVersion Include="Serilog.Sinks.ApplicationInsights" Version="4.0.1-dev-00040" />
     <PackageVersion Include="SQLite" Version="3.13.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
-    <PackageVersion Include="xunit" Version="2.6.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageVersion Include="xunit" Version="2.6.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.4" />
   </ItemGroup>
 </Project>

--- a/src/Clean.Architecture.Core/Clean.Architecture.Core.csproj
+++ b/src/Clean.Architecture.Core/Clean.Architecture.Core.csproj
@@ -1,11 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
 
-  <PropertyGroup>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" />
     <PackageReference Include="Ardalis.Result" />

--- a/src/Clean.Architecture.Infrastructure/Clean.Architecture.Infrastructure.csproj
+++ b/src/Clean.Architecture.Infrastructure/Clean.Architecture.Infrastructure.csproj
@@ -1,10 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
-  
-  <PropertyGroup>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Ardalis.SharedKernel" />

--- a/src/Clean.Architecture.UseCases/Clean.Architecture.UseCases.csproj
+++ b/src/Clean.Architecture.UseCases/Clean.Architecture.UseCases.csproj
@@ -1,15 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Ardalis.Result" />
     <PackageReference Include="MediatR" />
-    <PackageReference Include="MediatR.Extensions.Autofac.DependencyInjection" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
   </ItemGroup>
 

--- a/src/Clean.Architecture.Web/Clean.Architecture.Web.csproj
+++ b/src/Clean.Architecture.Web/Clean.Architecture.Web.csproj
@@ -5,8 +5,6 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <OutputType>Exe</OutputType>
     <WebProjectMode>true</WebProjectMode>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   
@@ -19,7 +17,6 @@
     <PackageReference Include="FastEndpoints.Swagger" />
 <!--    <PackageReference Include="FastEndpoints.Swagger.Swashbuckle" />-->
     <PackageReference Include="MediatR" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" PrivateAssets="All" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" />
     <PackageReference Include="Serilog.AspNetCore" />

--- a/tests/Clean.Architecture.FunctionalTests/Clean.Architecture.FunctionalTests.csproj
+++ b/tests/Clean.Architecture.FunctionalTests/Clean.Architecture.FunctionalTests.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
-  
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
@@ -21,7 +15,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
-    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Ardalis.HttpClientTestExtensions" />
   </ItemGroup>
 

--- a/tests/Clean.Architecture.IntegrationTests/Clean.Architecture.IntegrationTests.csproj
+++ b/tests/Clean.Architecture.IntegrationTests/Clean.Architecture.IntegrationTests.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
-  
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/tests/Clean.Architecture.UnitTests/Clean.Architecture.UnitTests.csproj
+++ b/tests/Clean.Architecture.UnitTests/Clean.Architecture.UnitTests.csproj
@@ -2,10 +2,7 @@
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Updates minor versions of some packages
- Cleans up project files by moving `nullable` and `ImplicitUsings` attributes to `Directory.Build.props` file
- Remove packages that are not in use
- Fixes build step in dotnetcore.yml to use latest stable .NET 8 version `8.0.100` and `actions/setup-dotnet@v3` (Test step still failing as expected because of Contributor list functional test)