### PR TITLE
Fix incorrect .NET version in launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/Clean.Architecture.Web/bin/Debug/net7.0/Clean.Architecture.Web.dll",
+            "program": "${workspaceFolder}/src/Clean.Architecture.Web/bin/Debug/net8.0/Clean.Architecture.Web.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Clean.Architecture.Web",
             "stopAtEntry": false,


### PR DESCRIPTION
Small change to make the life of us VSCode using folks a bit easier. I did not miss the irony of the comment just above it.

I was thinking the URL to be opened could be tweaked to use the path `/swagger/index.html` so that it follows the behaviour of starting the web project through `dotnet run`/`dotnet watch` ?