### PR TITLE
Fix Contributor List SQL

### DIFF
--- a/src/Clean.Architecture.Infrastructure/Data/Queries/ListContributorsQueryService.cs
+++ b/src/Clean.Architecture.Infrastructure/Data/Queries/ListContributorsQueryService.cs
@@ -12,7 +12,7 @@ public class ListContributorsQueryService(AppDbContext _db) : IListContributorsQ
   {
     // NOTE: This will fail if testing with EF InMemory provider
     var result = await _db.Database.SqlQuery<ContributorDTO>(
-      $"SELECT Id, Name, PhoneNumber_Number FROM Contributors") // don't fetch other big columns
+      $"SELECT Id, Name, COALESCE(PhoneNumber_Number, '') AS PhoneNumber FROM Contributors") // don't fetch other big columns
       //.Select(c => new ContributorDTO(c.Id, c.Name, c.PhoneNumber?.Number ?? ""))
       .ToListAsync();
 


### PR DESCRIPTION
Fixes #682 

- Alias the phone number column name so that it works with the `ContributorDTO`
- Convert NULL to empty string to work with the `ContributorDTO` `PhoneNumber` property which is a `string` and not a `string?`