### PR TITLE
Use injected logger directly in email sender classes

### DIFF
--- a/src/Clean.Architecture.Infrastructure/Data/Queries/FakeListContributorsQueryService.cs
+++ b/src/Clean.Architecture.Infrastructure/Data/Queries/FakeListContributorsQueryService.cs
@@ -7,10 +7,10 @@ public class FakeListContributorsQueryService : IListContributorsQueryService
 {
   public Task<IEnumerable<ContributorDTO>> ListAsync()
   {
-    List<ContributorDTO> result =
+    IEnumerable<ContributorDTO> result =
         [new ContributorDTO(1, "Fake Contributor 1", ""),
         new ContributorDTO(2, "Fake Contributor 2", "")];
 
-    return Task.FromResult(result.AsEnumerable());
+    return Task.FromResult(result);
   }
 }

--- a/src/Clean.Architecture.Infrastructure/Email/FakeEmailSender.cs
+++ b/src/Clean.Architecture.Infrastructure/Email/FakeEmailSender.cs
@@ -5,10 +5,9 @@ namespace Clean.Architecture.Infrastructure.Email;
 
 public class FakeEmailSender(ILogger<FakeEmailSender> logger) : IEmailSender
 {
-  private readonly ILogger<FakeEmailSender> _logger = logger;
   public Task SendEmailAsync(string to, string from, string subject, string body)
   {
-    _logger.LogInformation("Not actually sending an email to {to} from {from} with subject {subject}", to, from, subject);
+    logger.LogInformation("Not actually sending an email to {to} from {from} with subject {subject}", to, from, subject);
     return Task.CompletedTask;
   }
 }

--- a/src/Clean.Architecture.Infrastructure/Email/MimeKitEmailSender.cs
+++ b/src/Clean.Architecture.Infrastructure/Email/MimeKitEmailSender.cs
@@ -17,7 +17,7 @@ public class MimeKitEmailSender(ILogger<MimeKitEmailSender> logger,
     _logger.LogWarning("Sending email to {to} from {from} with subject {subject} using {type}.", to, from, subject, this.ToString());
 
     using var client = new SmtpClient(); 
-    client.Connect(_mailserverConfiguration.Hostname, 
+    await client.ConnectAsync(_mailserverConfiguration.Hostname, 
       _mailserverConfiguration.Port, false);
     var message = new MimeMessage();
     message.From.Add(new MailboxAddress(from, from));

--- a/src/Clean.Architecture.Infrastructure/Email/MimeKitEmailSender.cs
+++ b/src/Clean.Architecture.Infrastructure/Email/MimeKitEmailSender.cs
@@ -13,10 +13,10 @@ public class MimeKitEmailSender(ILogger<MimeKitEmailSender> logger,
 
   public async Task SendEmailAsync(string to, string from, string subject, string body)
   {
-    logger.LogWarning("Sending email to {to} from {from} with subject {subject} using {type}.", to, from, subject, this.ToString());
+    logger.LogWarning("Sending email to {to} from {from} with subject {subject} using {type}.", to, from, subject, typeof(MimeKitEmailSender).FullName);
 
-    using var client = new SmtpClient(); 
-    await client.ConnectAsync(_mailserverConfiguration.Hostname, 
+    using var client = new SmtpClient();
+    await client.ConnectAsync(_mailserverConfiguration.Hostname,
       _mailserverConfiguration.Port, false);
     var message = new MimeMessage();
     message.From.Add(new MailboxAddress(from, from));
@@ -26,7 +26,7 @@ public class MimeKitEmailSender(ILogger<MimeKitEmailSender> logger,
 
     await client.SendAsync(message);
 
-    await client.DisconnectAsync(true, 
+    await client.DisconnectAsync(true,
       new CancellationToken(canceled: true));
   }
 }

--- a/src/Clean.Architecture.Infrastructure/Email/MimeKitEmailSender.cs
+++ b/src/Clean.Architecture.Infrastructure/Email/MimeKitEmailSender.cs
@@ -9,12 +9,11 @@ namespace Clean.Architecture.Infrastructure.Email;
 public class MimeKitEmailSender(ILogger<MimeKitEmailSender> logger,
   IOptions<MailserverConfiguration> mailserverOptions) : IEmailSender
 {
-  private readonly ILogger<MimeKitEmailSender> _logger = logger;
   private readonly MailserverConfiguration _mailserverConfiguration = mailserverOptions.Value!;
 
   public async Task SendEmailAsync(string to, string from, string subject, string body)
   {
-    _logger.LogWarning("Sending email to {to} from {from} with subject {subject} using {type}.", to, from, subject, this.ToString());
+    logger.LogWarning("Sending email to {to} from {from} with subject {subject} using {type}.", to, from, subject, this.ToString());
 
     using var client = new SmtpClient(); 
     await client.ConnectAsync(_mailserverConfiguration.Hostname, 

--- a/src/Clean.Architecture.Infrastructure/Email/SmtpEmailSender.cs
+++ b/src/Clean.Architecture.Infrastructure/Email/SmtpEmailSender.cs
@@ -12,7 +12,6 @@ namespace Clean.Architecture.Infrastructure.Email;
 public class SmtpEmailSender(ILogger<SmtpEmailSender> logger,
                        IOptions<MailserverConfiguration> mailserverOptions) : IEmailSender
 {
-  private readonly ILogger<SmtpEmailSender> _logger = logger;
   private readonly MailserverConfiguration _mailserverConfiguration = mailserverOptions.Value!;
 
   public async Task SendEmailAsync(string to, string from, string subject, string body)
@@ -27,6 +26,6 @@ public class SmtpEmailSender(ILogger<SmtpEmailSender> logger,
     };
     message.To.Add(new MailAddress(to));
     await emailClient.SendMailAsync(message);
-    _logger.LogWarning("Sending email to {to} from {from} with subject {subject} using {type}.", to, from, subject, this.ToString());
+    logger.LogWarning("Sending email to {to} from {from} with subject {subject} using {type}.", to, from, subject, this.ToString());
   }
 }

--- a/src/Clean.Architecture.Infrastructure/Email/SmtpEmailSender.cs
+++ b/src/Clean.Architecture.Infrastructure/Email/SmtpEmailSender.cs
@@ -26,6 +26,6 @@ public class SmtpEmailSender(ILogger<SmtpEmailSender> logger,
     };
     message.To.Add(new MailAddress(to));
     await emailClient.SendMailAsync(message);
-    logger.LogWarning("Sending email to {to} from {from} with subject {subject} using {type}.", to, from, subject, this.ToString());
+    logger.LogWarning("Sending email to {to} from {from} with subject {subject} using {type}.", to, from, subject, typeof(SmtpEmailSender).FullName);
   }
 }


### PR DESCRIPTION
This pull request changes the email sender classes to use the injected logger directly in their methods.