### PR TITLE
Using GlobalUsings class file for commonly used namespaces

### DIFF
--- a/sample/src/NimblePros.SampleToDo.Infrastructure/Data/AppDbContext.cs
+++ b/sample/src/NimblePros.SampleToDo.Infrastructure/Data/AppDbContext.cs
@@ -1,8 +1,5 @@
-﻿using System.Reflection;
-using Ardalis.SharedKernel;
-using NimblePros.SampleToDo.Core.ContributorAggregate;
+﻿using NimblePros.SampleToDo.Core.ContributorAggregate;
 using NimblePros.SampleToDo.Core.ProjectAggregate;
-using Microsoft.EntityFrameworkCore;
 
 namespace NimblePros.SampleToDo.Infrastructure.Data;
 

--- a/sample/src/NimblePros.SampleToDo.Infrastructure/Data/Config/ContributorConfiguration.cs
+++ b/sample/src/NimblePros.SampleToDo.Infrastructure/Data/Config/ContributorConfiguration.cs
@@ -1,6 +1,4 @@
 ﻿using NimblePros.SampleToDo.Core.ContributorAggregate;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace NimblePros.SampleToDo.Infrastructure.Data.Config;
 

--- a/sample/src/NimblePros.SampleToDo.Infrastructure/Data/Config/ProjectConfiguration.cs
+++ b/sample/src/NimblePros.SampleToDo.Infrastructure/Data/Config/ProjectConfiguration.cs
@@ -1,6 +1,4 @@
 ﻿using NimblePros.SampleToDo.Core.ProjectAggregate;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace NimblePros.SampleToDo.Infrastructure.Data.Config;
 

--- a/sample/src/NimblePros.SampleToDo.Infrastructure/Data/Config/ToDoConfiguration.cs
+++ b/sample/src/NimblePros.SampleToDo.Infrastructure/Data/Config/ToDoConfiguration.cs
@@ -1,6 +1,4 @@
 ﻿using NimblePros.SampleToDo.Core.ProjectAggregate;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace NimblePros.SampleToDo.Infrastructure.Data.Config;
 

--- a/sample/src/NimblePros.SampleToDo.Infrastructure/Data/EfRepository.cs
+++ b/sample/src/NimblePros.SampleToDo.Infrastructure/Data/EfRepository.cs
@@ -1,7 +1,4 @@
-﻿using Ardalis.Specification.EntityFrameworkCore;
-using Ardalis.SharedKernel;
-
-namespace NimblePros.SampleToDo.Infrastructure.Data;
+﻿namespace NimblePros.SampleToDo.Infrastructure.Data;
 
 // inherit from Ardalis.Specification type
 public class EfRepository<T> : RepositoryBase<T>, IReadRepository<T>, IRepository<T> where T : class, IAggregateRoot

--- a/sample/src/NimblePros.SampleToDo.Infrastructure/Data/Queries/ListContributorsQueryService.cs
+++ b/sample/src/NimblePros.SampleToDo.Infrastructure/Data/Queries/ListContributorsQueryService.cs
@@ -1,5 +1,4 @@
 ﻿using NimblePros.SampleToDo.UseCases.Contributors;
-using Microsoft.EntityFrameworkCore;
 using NimblePros.SampleToDo.UseCases.Contributors.Queries.List;
 
 namespace NimblePros.SampleToDo.Infrastructure.Data.Queries;

--- a/sample/src/NimblePros.SampleToDo.Infrastructure/Data/Queries/ListIncompleteItemsQueryService.cs
+++ b/sample/src/NimblePros.SampleToDo.Infrastructure/Data/Queries/ListIncompleteItemsQueryService.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Data.SqlClient;
-using Microsoft.EntityFrameworkCore;
-using NimblePros.SampleToDo.UseCases.Projects;
+﻿using NimblePros.SampleToDo.UseCases.Projects;
 using NimblePros.SampleToDo.UseCases.Projects.ListIncompleteItems;
 
 namespace NimblePros.SampleToDo.Infrastructure.Data.Queries;

--- a/sample/src/NimblePros.SampleToDo.Infrastructure/Data/Queries/ListProjectsShallowQueryService.cs
+++ b/sample/src/NimblePros.SampleToDo.Infrastructure/Data/Queries/ListProjectsShallowQueryService.cs
@@ -1,6 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using NimblePros.SampleToDo.UseCases.Projects;
 using NimblePros.SampleToDo.UseCases.Projects.ListShallow;
-using NimblePros.SampleToDo.UseCases.Projects;
 
 namespace NimblePros.SampleToDo.Infrastructure.Data.Queries;
 

--- a/sample/src/NimblePros.SampleToDo.Infrastructure/Email/FakeEmailSender.cs
+++ b/sample/src/NimblePros.SampleToDo.Infrastructure/Email/FakeEmailSender.cs
@@ -1,5 +1,4 @@
 ﻿using NimblePros.SampleToDo.Core.Interfaces;
-using Microsoft.Extensions.Logging;
 
 namespace NimblePros.SampleToDo.Infrastructure.Email;
 

--- a/sample/src/NimblePros.SampleToDo.Infrastructure/Email/SmtpEmailSender.cs
+++ b/sample/src/NimblePros.SampleToDo.Infrastructure/Email/SmtpEmailSender.cs
@@ -1,6 +1,4 @@
-﻿using System.Net.Mail;
-using NimblePros.SampleToDo.Core.Interfaces;
-using Microsoft.Extensions.Logging;
+﻿using NimblePros.SampleToDo.Core.Interfaces;
 
 namespace NimblePros.SampleToDo.Infrastructure.Email;
 

--- a/sample/src/NimblePros.SampleToDo.Infrastructure/GlobalUsings.cs
+++ b/sample/src/NimblePros.SampleToDo.Infrastructure/GlobalUsings.cs
@@ -1,0 +1,9 @@
+﻿global using System.Net.Mail;
+global using System.Reflection;
+global using Ardalis.SharedKernel;
+global using Ardalis.Specification.EntityFrameworkCore;
+global using Microsoft.Data.SqlClient;
+global using Microsoft.EntityFrameworkCore;
+global using Microsoft.EntityFrameworkCore.Metadata.Builders;
+global using Microsoft.Extensions.DependencyInjection;
+global using Microsoft.Extensions.Logging;

--- a/sample/src/NimblePros.SampleToDo.Infrastructure/InfrastructureServiceExtensions.cs
+++ b/sample/src/NimblePros.SampleToDo.Infrastructure/InfrastructureServiceExtensions.cs
@@ -1,7 +1,4 @@
-﻿using Ardalis.SharedKernel;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using NimblePros.SampleToDo.Core.Interfaces;
+﻿using NimblePros.SampleToDo.Core.Interfaces;
 using NimblePros.SampleToDo.Infrastructure.Data;
 using NimblePros.SampleToDo.Infrastructure.Data.Queries;
 using NimblePros.SampleToDo.Infrastructure.Email;

--- a/sample/src/NimblePros.SampleToDo.UseCases/Contributors/Commands/Create/CreateContributorCommand.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Contributors/Commands/Create/CreateContributorCommand.cs
@@ -1,6 +1,4 @@
-﻿using Ardalis.Result;
-
-namespace NimblePros.SampleToDo.UseCases.Contributors.Commands.Create;
+﻿namespace NimblePros.SampleToDo.UseCases.Contributors.Commands.Create;
 
 /// <summary>
 /// Create a new Contributor.

--- a/sample/src/NimblePros.SampleToDo.UseCases/Contributors/Commands/Create/CreateContributorHandler.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Contributors/Commands/Create/CreateContributorHandler.cs
@@ -1,6 +1,4 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-using NimblePros.SampleToDo.Core.ContributorAggregate;
+﻿using NimblePros.SampleToDo.Core.ContributorAggregate;
 
 namespace NimblePros.SampleToDo.UseCases.Contributors.Commands.Create;
 

--- a/sample/src/NimblePros.SampleToDo.UseCases/Contributors/Commands/Delete/DeleteContributorCommand.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Contributors/Commands/Delete/DeleteContributorCommand.cs
@@ -1,6 +1,3 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-
-namespace NimblePros.SampleToDo.UseCases.Contributors.Commands.Delete;
+﻿namespace NimblePros.SampleToDo.UseCases.Contributors.Commands.Delete;
 
 public record DeleteContributorCommand(int ContributorId) : ICommand<Result>;

--- a/sample/src/NimblePros.SampleToDo.UseCases/Contributors/Commands/Delete/DeleteContributorHandler.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Contributors/Commands/Delete/DeleteContributorHandler.cs
@@ -1,6 +1,4 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-using NimblePros.SampleToDo.Core.Interfaces;
+﻿using NimblePros.SampleToDo.Core.Interfaces;
 
 namespace NimblePros.SampleToDo.UseCases.Contributors.Commands.Delete;
 

--- a/sample/src/NimblePros.SampleToDo.UseCases/Contributors/Commands/Update/UpdateContributorCommand.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Contributors/Commands/Update/UpdateContributorCommand.cs
@@ -1,6 +1,3 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-
-namespace NimblePros.SampleToDo.UseCases.Contributors.Commands.Update;
+﻿namespace NimblePros.SampleToDo.UseCases.Contributors.Commands.Update;
 
 public record UpdateContributorCommand(int ContributorId, string NewName) : ICommand<Result<ContributorDTO>>;

--- a/sample/src/NimblePros.SampleToDo.UseCases/Contributors/Commands/Update/UpdateContributorHandler.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Contributors/Commands/Update/UpdateContributorHandler.cs
@@ -1,6 +1,4 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-using NimblePros.SampleToDo.Core.ContributorAggregate;
+﻿using NimblePros.SampleToDo.Core.ContributorAggregate;
 
 namespace NimblePros.SampleToDo.UseCases.Contributors.Commands.Update;
 

--- a/sample/src/NimblePros.SampleToDo.UseCases/Contributors/Queries/Get/GetContributorHandler.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Contributors/Queries/Get/GetContributorHandler.cs
@@ -1,6 +1,4 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-using NimblePros.SampleToDo.Core.ContributorAggregate;
+﻿using NimblePros.SampleToDo.Core.ContributorAggregate;
 using NimblePros.SampleToDo.Core.ContributorAggregate.Specifications;
 
 namespace NimblePros.SampleToDo.UseCases.Contributors.Queries.Get;

--- a/sample/src/NimblePros.SampleToDo.UseCases/Contributors/Queries/Get/GetContributorQuery.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Contributors/Queries/Get/GetContributorQuery.cs
@@ -1,6 +1,3 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-
-namespace NimblePros.SampleToDo.UseCases.Contributors.Queries.Get;
+﻿namespace NimblePros.SampleToDo.UseCases.Contributors.Queries.Get;
 
 public record GetContributorQuery(int ContributorId) : IQuery<Result<ContributorDTO>>;

--- a/sample/src/NimblePros.SampleToDo.UseCases/Contributors/Queries/List/ListContributorsHandler.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Contributors/Queries/List/ListContributorsHandler.cs
@@ -1,7 +1,4 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-
-namespace NimblePros.SampleToDo.UseCases.Contributors.Queries.List;
+﻿namespace NimblePros.SampleToDo.UseCases.Contributors.Queries.List;
 
 public class ListContributorsHandler : IQueryHandler<ListContributorsQuery, Result<IEnumerable<ContributorDTO>>>
 {

--- a/sample/src/NimblePros.SampleToDo.UseCases/Contributors/Queries/List/ListContributorsQuery.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Contributors/Queries/List/ListContributorsQuery.cs
@@ -1,6 +1,3 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-
-namespace NimblePros.SampleToDo.UseCases.Contributors.Queries.List;
+﻿namespace NimblePros.SampleToDo.UseCases.Contributors.Queries.List;
 
 public record ListContributorsQuery(int? Skip, int? Take) : IQuery<Result<IEnumerable<ContributorDTO>>>;

--- a/sample/src/NimblePros.SampleToDo.UseCases/GlobalUsings.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/GlobalUsings.cs
@@ -1,0 +1,2 @@
+﻿global using Ardalis.Result;
+global using Ardalis.SharedKernel;

--- a/sample/src/NimblePros.SampleToDo.UseCases/NimblePros.SampleToDo.UseCases.csproj
+++ b/sample/src/NimblePros.SampleToDo.UseCases/NimblePros.SampleToDo.UseCases.csproj
@@ -6,6 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Projects\AddContributorToItem\**" />
+    <EmbeddedResource Remove="Projects\AddContributorToItem\**" />
+    <None Remove="Projects\AddContributorToItem\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Ardalis.Result" />
     <PackageReference Include="MediatR" />
     <PackageReference Include="MediatR.Extensions.Autofac.DependencyInjection" />
@@ -14,10 +20,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\NimblePros.SampleToDo.Core\NimblePros.SampleToDo.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Projects\AddContributorToItem\" />
   </ItemGroup>
 
 </Project>

--- a/sample/src/NimblePros.SampleToDo.UseCases/Projects/AddToDoItem/AddToDoItemCommand.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Projects/AddToDoItem/AddToDoItemCommand.cs
@@ -1,6 +1,4 @@
-﻿using Ardalis.Result;
-
-namespace NimblePros.SampleToDo.UseCases.Projects.AddToDoItem;
+﻿namespace NimblePros.SampleToDo.UseCases.Projects.AddToDoItem;
 
 /// <summary>
 /// Creates a new ToDoItem and adds it to a Project

--- a/sample/src/NimblePros.SampleToDo.UseCases/Projects/AddToDoItem/AddToDoItemHandler.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Projects/AddToDoItem/AddToDoItemHandler.cs
@@ -1,6 +1,4 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-using NimblePros.SampleToDo.Core.ProjectAggregate;
+﻿using NimblePros.SampleToDo.Core.ProjectAggregate;
 using NimblePros.SampleToDo.Core.ProjectAggregate.Specifications;
 
 namespace NimblePros.SampleToDo.UseCases.Projects.AddToDoItem;

--- a/sample/src/NimblePros.SampleToDo.UseCases/Projects/Create/CreateProjectCommand.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Projects/Create/CreateProjectCommand.cs
@@ -1,6 +1,4 @@
-﻿using Ardalis.Result;
-
-namespace NimblePros.SampleToDo.UseCases.Projects.Create;
+﻿namespace NimblePros.SampleToDo.UseCases.Projects.Create;
 
 /// <summary>
 /// Create a new Project.

--- a/sample/src/NimblePros.SampleToDo.UseCases/Projects/Create/CreateProjectHandler.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Projects/Create/CreateProjectHandler.cs
@@ -1,6 +1,4 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-using NimblePros.SampleToDo.Core.ProjectAggregate;
+﻿using NimblePros.SampleToDo.Core.ProjectAggregate;
 
 namespace NimblePros.SampleToDo.UseCases.Projects.Create;
 

--- a/sample/src/NimblePros.SampleToDo.UseCases/Projects/Delete/DeleteProjectCommand.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Projects/Delete/DeleteProjectCommand.cs
@@ -1,6 +1,3 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-
-namespace NimblePros.SampleToDo.UseCases.Projects.Delete;
+﻿namespace NimblePros.SampleToDo.UseCases.Projects.Delete;
 
 public record DeleteProjectCommand(int ProjectId) : ICommand<Result>;

--- a/sample/src/NimblePros.SampleToDo.UseCases/Projects/Delete/DeleteProjectHandler.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Projects/Delete/DeleteProjectHandler.cs
@@ -1,6 +1,4 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-using NimblePros.SampleToDo.Core.ProjectAggregate;
+﻿using NimblePros.SampleToDo.Core.ProjectAggregate;
 
 namespace NimblePros.SampleToDo.UseCases.Projects.Delete;
 

--- a/sample/src/NimblePros.SampleToDo.UseCases/Projects/GetWithAllItems/GetProjectWithAllItemsHandler.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Projects/GetWithAllItems/GetProjectWithAllItemsHandler.cs
@@ -1,6 +1,4 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-using NimblePros.SampleToDo.Core.ProjectAggregate;
+﻿using NimblePros.SampleToDo.Core.ProjectAggregate;
 using NimblePros.SampleToDo.Core.ProjectAggregate.Specifications;
 
 namespace NimblePros.SampleToDo.UseCases.Projects.GetWithAllItems;

--- a/sample/src/NimblePros.SampleToDo.UseCases/Projects/GetWithAllItems/GetProjectWithAllItemsQuery.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Projects/GetWithAllItems/GetProjectWithAllItemsQuery.cs
@@ -1,6 +1,3 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-
-namespace NimblePros.SampleToDo.UseCases.Projects.GetWithAllItems;
+﻿namespace NimblePros.SampleToDo.UseCases.Projects.GetWithAllItems;
 
 public record GetProjectWithAllItemsQuery(int ProjectId) : IQuery<Result<ProjectWithAllItemsDTO>>;

--- a/sample/src/NimblePros.SampleToDo.UseCases/Projects/ListIncompleteItems/ListIncompleteItemsByProjectHandler.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Projects/ListIncompleteItems/ListIncompleteItemsByProjectHandler.cs
@@ -1,7 +1,4 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-
-namespace NimblePros.SampleToDo.UseCases.Projects.ListIncompleteItems;
+﻿namespace NimblePros.SampleToDo.UseCases.Projects.ListIncompleteItems;
 
 public class ListIncompleteItemsByProjectHandler : IQueryHandler<ListIncompleteItemsByProjectQuery, Result<IEnumerable<ToDoItemDTO>>>
 {

--- a/sample/src/NimblePros.SampleToDo.UseCases/Projects/ListIncompleteItems/ListIncompleteItemsByProjectQuery.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Projects/ListIncompleteItems/ListIncompleteItemsByProjectQuery.cs
@@ -1,6 +1,3 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-
-namespace NimblePros.SampleToDo.UseCases.Projects.ListIncompleteItems;
+﻿namespace NimblePros.SampleToDo.UseCases.Projects.ListIncompleteItems;
 
 public record ListIncompleteItemsByProjectQuery(int ProjectId) : IQuery<Result<IEnumerable<ToDoItemDTO>>>;

--- a/sample/src/NimblePros.SampleToDo.UseCases/Projects/ListShallow/ListProjectsShallowHandler.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Projects/ListShallow/ListProjectsShallowHandler.cs
@@ -1,7 +1,4 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-
-namespace NimblePros.SampleToDo.UseCases.Projects.ListShallow;
+﻿namespace NimblePros.SampleToDo.UseCases.Projects.ListShallow;
 
 public class ListProjectsShallowHandler(IListProjectsShallowQueryService query)
   : IQueryHandler<ListProjectsShallowQuery, Result<IEnumerable<ProjectDTO>>>

--- a/sample/src/NimblePros.SampleToDo.UseCases/Projects/ListShallow/ListProjectsShallowQuery.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Projects/ListShallow/ListProjectsShallowQuery.cs
@@ -1,6 +1,3 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-
-namespace NimblePros.SampleToDo.UseCases.Projects.ListShallow;
+﻿namespace NimblePros.SampleToDo.UseCases.Projects.ListShallow;
 
 public record ListProjectsShallowQuery(int? Skip, int? Take) : IQuery<Result<IEnumerable<ProjectDTO>>>;

--- a/sample/src/NimblePros.SampleToDo.UseCases/Projects/MarkToDoItemComplete/MarkToDoItemCompleteCommand.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Projects/MarkToDoItemComplete/MarkToDoItemCompleteCommand.cs
@@ -1,6 +1,4 @@
-﻿using Ardalis.Result;
-
-namespace NimblePros.SampleToDo.UseCases.Projects.MarkToDoItemComplete;
+﻿namespace NimblePros.SampleToDo.UseCases.Projects.MarkToDoItemComplete;
 
 /// <summary>
 /// Create a new Project.

--- a/sample/src/NimblePros.SampleToDo.UseCases/Projects/MarkToDoItemComplete/MarkToDoItemCompleteHandler.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Projects/MarkToDoItemComplete/MarkToDoItemCompleteHandler.cs
@@ -1,6 +1,4 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-using NimblePros.SampleToDo.Core.ProjectAggregate;
+﻿using NimblePros.SampleToDo.Core.ProjectAggregate;
 using NimblePros.SampleToDo.Core.ProjectAggregate.Specifications;
 
 namespace NimblePros.SampleToDo.UseCases.Projects.MarkToDoItemComplete;

--- a/sample/src/NimblePros.SampleToDo.UseCases/Projects/Update/UpdateContributorHandler.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Projects/Update/UpdateContributorHandler.cs
@@ -1,6 +1,4 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-using NimblePros.SampleToDo.Core.ProjectAggregate;
+﻿using NimblePros.SampleToDo.Core.ProjectAggregate;
 using NimblePros.SampleToDo.UseCases.Projects;
 using NimblePros.SampleToDo.UseCases.Projects.Update;
 

--- a/sample/src/NimblePros.SampleToDo.UseCases/Projects/Update/UpdateProjectCommand.cs
+++ b/sample/src/NimblePros.SampleToDo.UseCases/Projects/Update/UpdateProjectCommand.cs
@@ -1,6 +1,3 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-
-namespace NimblePros.SampleToDo.UseCases.Projects.Update;
+﻿namespace NimblePros.SampleToDo.UseCases.Projects.Update;
 
 public record UpdateProjectCommand(int ProjectId, string NewName) : ICommand<Result<ProjectDTO>>;

--- a/sample/src/NimblePros.SampleToDo.Web/Contributors/Create.cs
+++ b/sample/src/NimblePros.SampleToDo.Web/Contributors/Create.cs
@@ -1,6 +1,4 @@
-﻿using FastEndpoints;
-using MediatR;
-using NimblePros.SampleToDo.UseCases.Contributors.Commands.Create;
+﻿using NimblePros.SampleToDo.UseCases.Contributors.Commands.Create;
 
 namespace NimblePros.SampleToDo.Web.Contributors;
 

--- a/sample/src/NimblePros.SampleToDo.Web/Contributors/Delete.cs
+++ b/sample/src/NimblePros.SampleToDo.Web/Contributors/Delete.cs
@@ -1,7 +1,4 @@
-﻿using Ardalis.Result;
-using FastEndpoints;
-using MediatR;
-using NimblePros.SampleToDo.UseCases.Contributors.Commands.Delete;
+﻿using NimblePros.SampleToDo.UseCases.Contributors.Commands.Delete;
 
 namespace NimblePros.SampleToDo.Web.Contributors;
 

--- a/sample/src/NimblePros.SampleToDo.Web/Contributors/GetById.cs
+++ b/sample/src/NimblePros.SampleToDo.Web/Contributors/GetById.cs
@@ -1,7 +1,4 @@
-﻿using Ardalis.Result;
-using FastEndpoints;
-using MediatR;
-using NimblePros.SampleToDo.UseCases.Contributors.Queries.Get;
+﻿using NimblePros.SampleToDo.UseCases.Contributors.Queries.Get;
 
 namespace NimblePros.SampleToDo.Web.Contributors;
 

--- a/sample/src/NimblePros.SampleToDo.Web/Contributors/List.cs
+++ b/sample/src/NimblePros.SampleToDo.Web/Contributors/List.cs
@@ -1,6 +1,4 @@
-﻿using FastEndpoints;
-using MediatR;
-using NimblePros.SampleToDo.UseCases.Contributors.Queries.List;
+﻿using NimblePros.SampleToDo.UseCases.Contributors.Queries.List;
 
 namespace NimblePros.SampleToDo.Web.Contributors;
 

--- a/sample/src/NimblePros.SampleToDo.Web/Contributors/Update.cs
+++ b/sample/src/NimblePros.SampleToDo.Web/Contributors/Update.cs
@@ -1,8 +1,4 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-using FastEndpoints;
-using MediatR;
-using NimblePros.SampleToDo.Core.ContributorAggregate;
+﻿using NimblePros.SampleToDo.Core.ContributorAggregate;
 using NimblePros.SampleToDo.UseCases.Contributors.Commands.Update;
 
 namespace NimblePros.SampleToDo.Web.Contributors;

--- a/sample/src/NimblePros.SampleToDo.Web/GlobalUsings.cs
+++ b/sample/src/NimblePros.SampleToDo.Web/GlobalUsings.cs
@@ -1,0 +1,10 @@
+﻿global using System.Reflection;
+global using Ardalis.ListStartupServices;
+global using Ardalis.Result;
+global using Ardalis.SharedKernel;
+global using FastEndpoints;
+global using FastEndpoints.Swagger;
+global using MediatR;
+global using Microsoft.EntityFrameworkCore;
+global using Serilog;
+global using Serilog.Extensions.Logging;

--- a/sample/src/NimblePros.SampleToDo.Web/Program.cs
+++ b/sample/src/NimblePros.SampleToDo.Web/Program.cs
@@ -1,19 +1,9 @@
-﻿using System.Reflection;
-using Ardalis.ListStartupServices;
-using Ardalis.SharedKernel;
-using NimblePros.SampleToDo.Core;
+﻿using NimblePros.SampleToDo.Core;
+using NimblePros.SampleToDo.Core.ProjectAggregate;
 using NimblePros.SampleToDo.Infrastructure;
 using NimblePros.SampleToDo.Infrastructure.Data;
-using NimblePros.SampleToDo.Web;
-using FastEndpoints;
-using FastEndpoints.Swagger;
-using FastEndpoints.ApiExplorer;
-using MediatR;
-using Serilog;
-using Microsoft.EntityFrameworkCore;
-using NimblePros.SampleToDo.Core.ProjectAggregate;
-using Serilog.Extensions.Logging;
 using NimblePros.SampleToDo.UseCases.Contributors.Commands.Create;
+using NimblePros.SampleToDo.Web;
 
 var logger = Log.Logger = new LoggerConfiguration()
   .Enrich.FromLogContext()

--- a/sample/src/NimblePros.SampleToDo.Web/Projects/Create.cs
+++ b/sample/src/NimblePros.SampleToDo.Web/Projects/Create.cs
@@ -1,6 +1,4 @@
-﻿using FastEndpoints;
-using MediatR;
-using NimblePros.SampleToDo.UseCases.Projects.Create;
+﻿using NimblePros.SampleToDo.UseCases.Projects.Create;
 
 namespace NimblePros.SampleToDo.Web.Projects;
 

--- a/sample/src/NimblePros.SampleToDo.Web/Projects/CreateToDoItem.cs
+++ b/sample/src/NimblePros.SampleToDo.Web/Projects/CreateToDoItem.cs
@@ -1,6 +1,4 @@
-﻿using FastEndpoints;
-using MediatR;
-using NimblePros.SampleToDo.UseCases.Projects.AddToDoItem;
+﻿using NimblePros.SampleToDo.UseCases.Projects.AddToDoItem;
 using NimblePros.SampleToDo.Web.Projects;
 
 namespace NimblePros.SampleToDo.Web.ProjectEndpoints;

--- a/sample/src/NimblePros.SampleToDo.Web/Projects/Delete.cs
+++ b/sample/src/NimblePros.SampleToDo.Web/Projects/Delete.cs
@@ -1,7 +1,4 @@
-﻿using Ardalis.Result;
-using FastEndpoints;
-using MediatR;
-using NimblePros.SampleToDo.UseCases.Projects.Delete;
+﻿using NimblePros.SampleToDo.UseCases.Projects.Delete;
 
 namespace NimblePros.SampleToDo.Web.Projects;
 

--- a/sample/src/NimblePros.SampleToDo.Web/Projects/GetById.cs
+++ b/sample/src/NimblePros.SampleToDo.Web/Projects/GetById.cs
@@ -1,7 +1,4 @@
-﻿using Ardalis.Result;
-using FastEndpoints;
-using MediatR;
-using NimblePros.SampleToDo.UseCases.Projects.GetWithAllItems;
+﻿using NimblePros.SampleToDo.UseCases.Projects.GetWithAllItems;
 using NimblePros.SampleToDo.Web.Endpoints.Projects;
 
 namespace NimblePros.SampleToDo.Web.Projects;

--- a/sample/src/NimblePros.SampleToDo.Web/Projects/List.cs
+++ b/sample/src/NimblePros.SampleToDo.Web/Projects/List.cs
@@ -1,6 +1,4 @@
-﻿using FastEndpoints;
-using MediatR;
-using NimblePros.SampleToDo.Core.ProjectAggregate;
+﻿using NimblePros.SampleToDo.Core.ProjectAggregate;
 using NimblePros.SampleToDo.UseCases.Projects.ListShallow;
 
 namespace NimblePros.SampleToDo.Web.Projects;

--- a/sample/src/NimblePros.SampleToDo.Web/Projects/ListIncompleteItems.cs
+++ b/sample/src/NimblePros.SampleToDo.Web/Projects/ListIncompleteItems.cs
@@ -1,7 +1,4 @@
-﻿using Ardalis.Result;
-using FastEndpoints;
-using MediatR;
-using NimblePros.SampleToDo.UseCases.Projects.ListIncompleteItems;
+﻿using NimblePros.SampleToDo.UseCases.Projects.ListIncompleteItems;
 using NimblePros.SampleToDo.Web.Endpoints.ProjectEndpoints;
 
 namespace NimblePros.SampleToDo.Web.Projects;

--- a/sample/src/NimblePros.SampleToDo.Web/Projects/MarkItemComplete.cs
+++ b/sample/src/NimblePros.SampleToDo.Web/Projects/MarkItemComplete.cs
@@ -1,6 +1,4 @@
-﻿using FastEndpoints;
-using MediatR;
-using NimblePros.SampleToDo.UseCases.Projects.MarkToDoItemComplete;
+﻿using NimblePros.SampleToDo.UseCases.Projects.MarkToDoItemComplete;
 
 namespace NimblePros.SampleToDo.Web.ProjectEndpoints;
 

--- a/sample/src/NimblePros.SampleToDo.Web/Projects/Update.cs
+++ b/sample/src/NimblePros.SampleToDo.Web/Projects/Update.cs
@@ -1,14 +1,4 @@
-﻿using NimblePros.SampleToDo.Core.ProjectAggregate;
-using Ardalis.SharedKernel;
-using Microsoft.AspNetCore.Mvc;
-//using Swashbuckle.AspNetCore.Annotations;
-using NimblePros.SampleToDo.Web.Endpoints.ProjectEndpoints;
-using FastEndpoints;
-using NimblePros.SampleToDo.Web.Contributors;
-using MediatR;
-using Ardalis.Result;
-using NimblePros.SampleToDo.UseCases.Contributors.Update;
-using NimblePros.SampleToDo.UseCases.Projects.Update;
+﻿using NimblePros.SampleToDo.UseCases.Projects.Update;
 
 namespace NimblePros.SampleToDo.Web.Projects;
 

--- a/sample/src/NimblePros.SampleToDo.Web/SeedData.cs
+++ b/sample/src/NimblePros.SampleToDo.Web/SeedData.cs
@@ -1,7 +1,6 @@
 ﻿using NimblePros.SampleToDo.Core.ContributorAggregate;
 using NimblePros.SampleToDo.Core.ProjectAggregate;
 using NimblePros.SampleToDo.Infrastructure.Data;
-using Microsoft.EntityFrameworkCore;
 
 namespace NimblePros.SampleToDo.Web;
 

--- a/sample/tests/NimblePros.SampleToDo.FunctionalTests/Contributors/ContributorCreate.cs
+++ b/sample/tests/NimblePros.SampleToDo.FunctionalTests/Contributors/ContributorCreate.cs
@@ -1,7 +1,4 @@
-﻿using Ardalis.HttpClientTestExtensions;
-using FluentAssertions;
-using NimblePros.SampleToDo.Web.Contributors;
-using Xunit;
+﻿using NimblePros.SampleToDo.Web.Contributors;
 
 namespace NimblePros.SampleToDo.FunctionalTests.Contributors;
 

--- a/sample/tests/NimblePros.SampleToDo.FunctionalTests/Contributors/ContributorDelete.cs
+++ b/sample/tests/NimblePros.SampleToDo.FunctionalTests/Contributors/ContributorDelete.cs
@@ -1,7 +1,5 @@
-﻿using Ardalis.HttpClientTestExtensions;
-using NimblePros.SampleToDo.Web;
+﻿using NimblePros.SampleToDo.Web;
 using NimblePros.SampleToDo.Web.Contributors;
-using Xunit;
 
 namespace NimblePros.SampleToDo.FunctionalTests.Contributors;
 

--- a/sample/tests/NimblePros.SampleToDo.FunctionalTests/Contributors/ContributorGetById.cs
+++ b/sample/tests/NimblePros.SampleToDo.FunctionalTests/Contributors/ContributorGetById.cs
@@ -1,7 +1,5 @@
-﻿using Ardalis.HttpClientTestExtensions;
-using NimblePros.SampleToDo.Web;
+﻿using NimblePros.SampleToDo.Web;
 using NimblePros.SampleToDo.Web.Contributors;
-using Xunit;
 
 namespace NimblePros.SampleToDo.FunctionalTests.Contributors;
 

--- a/sample/tests/NimblePros.SampleToDo.FunctionalTests/Contributors/ContributorList.cs
+++ b/sample/tests/NimblePros.SampleToDo.FunctionalTests/Contributors/ContributorList.cs
@@ -1,7 +1,5 @@
-﻿using Ardalis.HttpClientTestExtensions;
-using NimblePros.SampleToDo.Web;
+﻿using NimblePros.SampleToDo.Web;
 using NimblePros.SampleToDo.Web.Contributors;
-using Xunit;
 
 namespace NimblePros.SampleToDo.FunctionalTests.Contributors;
 

--- a/sample/tests/NimblePros.SampleToDo.FunctionalTests/Contributors/ContributorUpdate.cs
+++ b/sample/tests/NimblePros.SampleToDo.FunctionalTests/Contributors/ContributorUpdate.cs
@@ -1,8 +1,5 @@
-﻿using Ardalis.HttpClientTestExtensions;
-using FluentAssertions;
-using NimblePros.SampleToDo.Web;
+﻿using NimblePros.SampleToDo.Web;
 using NimblePros.SampleToDo.Web.Contributors;
-using Xunit;
 
 namespace NimblePros.SampleToDo.FunctionalTests.Contributors;
 

--- a/sample/tests/NimblePros.SampleToDo.FunctionalTests/CustomWebApplicationFactory.cs
+++ b/sample/tests/NimblePros.SampleToDo.FunctionalTests/CustomWebApplicationFactory.cs
@@ -1,10 +1,4 @@
-﻿using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using NimblePros.SampleToDo.Infrastructure.Data;
+﻿using NimblePros.SampleToDo.Infrastructure.Data;
 using NimblePros.SampleToDo.UseCases.Contributors.Commands.Create;
 using NimblePros.SampleToDo.Web;
 

--- a/sample/tests/NimblePros.SampleToDo.FunctionalTests/Fixtures/SmtpServerFixture.cs
+++ b/sample/tests/NimblePros.SampleToDo.FunctionalTests/Fixtures/SmtpServerFixture.cs
@@ -1,8 +1,4 @@
-﻿using DotNet.Testcontainers.Builders;
-using DotNet.Testcontainers.Containers;
-using Xunit;
-
-namespace NimblePros.SampleToDo.FunctionalTests.ClassFixtures;
+﻿namespace NimblePros.SampleToDo.FunctionalTests.ClassFixtures;
 
 /// <summary>
 /// This class ensures that an SMTP server is running and shared between all tests in a specified class.

--- a/sample/tests/NimblePros.SampleToDo.FunctionalTests/GlobalUsings.cs
+++ b/sample/tests/NimblePros.SampleToDo.FunctionalTests/GlobalUsings.cs
@@ -1,0 +1,13 @@
+﻿global using System.Text;
+global using Ardalis.HttpClientTestExtensions;
+global using DotNet.Testcontainers.Builders;
+global using DotNet.Testcontainers.Containers;
+global using FluentAssertions;
+global using Microsoft.AspNetCore.Hosting;
+global using Microsoft.AspNetCore.Mvc.Testing;
+global using Microsoft.EntityFrameworkCore;
+global using Microsoft.Extensions.DependencyInjection;
+global using Microsoft.Extensions.Hosting;
+global using Microsoft.Extensions.Logging;
+global using Newtonsoft.Json;
+global using Xunit;

--- a/sample/tests/NimblePros.SampleToDo.FunctionalTests/Projects/ProjectAddToDoItem.cs
+++ b/sample/tests/NimblePros.SampleToDo.FunctionalTests/Projects/ProjectAddToDoItem.cs
@@ -1,7 +1,4 @@
-﻿using Ardalis.HttpClientTestExtensions;
-using Xunit;
-using FluentAssertions;
-using NimblePros.SampleToDo.Web;
+﻿using NimblePros.SampleToDo.Web;
 using NimblePros.SampleToDo.Web.Projects;
 using NimblePros.SampleToDo.Web.Endpoints.Projects;
 

--- a/sample/tests/NimblePros.SampleToDo.FunctionalTests/Projects/ProjectCreate.cs
+++ b/sample/tests/NimblePros.SampleToDo.FunctionalTests/Projects/ProjectCreate.cs
@@ -1,7 +1,4 @@
-﻿using Ardalis.HttpClientTestExtensions;
-using FluentAssertions;
-using NimblePros.SampleToDo.Web.Projects;
-using Xunit;
+﻿using NimblePros.SampleToDo.Web.Projects;
 
 namespace NimblePros.SampleToDo.FunctionalTests.Projects;
 

--- a/sample/tests/NimblePros.SampleToDo.FunctionalTests/Projects/ProjectGetById.cs
+++ b/sample/tests/NimblePros.SampleToDo.FunctionalTests/Projects/ProjectGetById.cs
@@ -1,8 +1,6 @@
-﻿using Ardalis.HttpClientTestExtensions;
-using NimblePros.SampleToDo.Web;
+﻿using NimblePros.SampleToDo.Web;
 using NimblePros.SampleToDo.Web.Endpoints.Projects;
 using NimblePros.SampleToDo.Web.Projects;
-using Xunit;
 
 namespace NimblePros.SampleToDo.FunctionalTests.Projects;
 

--- a/sample/tests/NimblePros.SampleToDo.FunctionalTests/Projects/ProjectItemMarkComplete.cs
+++ b/sample/tests/NimblePros.SampleToDo.FunctionalTests/Projects/ProjectItemMarkComplete.cs
@@ -1,12 +1,7 @@
-﻿using System.Text;
-using Newtonsoft.Json;
-using Xunit;
-using NimblePros.SampleToDo.Web.ProjectEndpoints;
-using Ardalis.HttpClientTestExtensions;
+﻿using NimblePros.SampleToDo.FunctionalTests.ClassFixtures;
 using NimblePros.SampleToDo.Web.Endpoints.Projects;
+using NimblePros.SampleToDo.Web.ProjectEndpoints;
 using NimblePros.SampleToDo.Web.Projects;
-using FluentAssertions;
-using NimblePros.SampleToDo.FunctionalTests.ClassFixtures;
 
 namespace NimblePros.SampleToDo.FunctionalTests.Projects;
 

--- a/sample/tests/NimblePros.SampleToDo.FunctionalTests/Projects/ProjectList.cs
+++ b/sample/tests/NimblePros.SampleToDo.FunctionalTests/Projects/ProjectList.cs
@@ -1,7 +1,5 @@
-﻿using Ardalis.HttpClientTestExtensions;
-using NimblePros.SampleToDo.Web;
+﻿using NimblePros.SampleToDo.Web;
 using NimblePros.SampleToDo.Web.Projects;
-using Xunit;
 
 namespace NimblePros.SampleToDo.FunctionalTests.Projects;
 

--- a/sample/tests/NimblePros.SampleToDo.IntegrationTests/Data/BaseEfRepoTestFixture.cs
+++ b/sample/tests/NimblePros.SampleToDo.IntegrationTests/Data/BaseEfRepoTestFixture.cs
@@ -1,9 +1,5 @@
 ﻿using NimblePros.SampleToDo.Core.ProjectAggregate;
 using NimblePros.SampleToDo.Infrastructure.Data;
-using Ardalis.SharedKernel;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
-using NSubstitute;
 
 namespace NimblePros.SampleToDo.IntegrationTests.Data;
 

--- a/sample/tests/NimblePros.SampleToDo.IntegrationTests/Data/EfRepositoryAdd.cs
+++ b/sample/tests/NimblePros.SampleToDo.IntegrationTests/Data/EfRepositoryAdd.cs
@@ -1,5 +1,4 @@
 ﻿using NimblePros.SampleToDo.Core.ProjectAggregate;
-using Xunit;
 
 namespace NimblePros.SampleToDo.IntegrationTests.Data;
 

--- a/sample/tests/NimblePros.SampleToDo.IntegrationTests/Data/EfRepositoryDelete.cs
+++ b/sample/tests/NimblePros.SampleToDo.IntegrationTests/Data/EfRepositoryDelete.cs
@@ -1,5 +1,4 @@
 ﻿using NimblePros.SampleToDo.Core.ProjectAggregate;
-using Xunit;
 
 namespace NimblePros.SampleToDo.IntegrationTests.Data;
 

--- a/sample/tests/NimblePros.SampleToDo.IntegrationTests/Data/EfRepositoryUpdate.cs
+++ b/sample/tests/NimblePros.SampleToDo.IntegrationTests/Data/EfRepositoryUpdate.cs
@@ -1,6 +1,4 @@
 ﻿using NimblePros.SampleToDo.Core.ProjectAggregate;
-using Microsoft.EntityFrameworkCore;
-using Xunit;
 
 namespace NimblePros.SampleToDo.IntegrationTests.Data;
 

--- a/sample/tests/NimblePros.SampleToDo.IntegrationTests/GlobalUsings.cs
+++ b/sample/tests/NimblePros.SampleToDo.IntegrationTests/GlobalUsings.cs
@@ -1,0 +1,5 @@
+﻿global using Ardalis.SharedKernel;
+global using Microsoft.EntityFrameworkCore;
+global using NSubstitute;
+global using Xunit;
+global using Microsoft.Extensions.DependencyInjection;

--- a/sample/tests/NimblePros.SampleToDo.UnitTests/Core/ContributorAggregate/ContributorConstructor.cs
+++ b/sample/tests/NimblePros.SampleToDo.UnitTests/Core/ContributorAggregate/ContributorConstructor.cs
@@ -1,5 +1,4 @@
 ﻿using NimblePros.SampleToDo.Core.ContributorAggregate;
-using Xunit;
 
 namespace NimblePros.SampleToDo.UnitTests.Core.ContributorAggregate;
 

--- a/sample/tests/NimblePros.SampleToDo.UnitTests/Core/Handlers/ItemCompletedEmailNotificationHandlerHandle.cs
+++ b/sample/tests/NimblePros.SampleToDo.UnitTests/Core/Handlers/ItemCompletedEmailNotificationHandlerHandle.cs
@@ -2,8 +2,6 @@
 using NimblePros.SampleToDo.Core.ProjectAggregate;
 using NimblePros.SampleToDo.Core.ProjectAggregate.Events;
 using NimblePros.SampleToDo.Core.ProjectAggregate.Handlers;
-using Xunit;
-using NSubstitute;
 
 namespace NimblePros.SampleToDo.UnitTests.Core.Handlers;
 

--- a/sample/tests/NimblePros.SampleToDo.UnitTests/Core/ProjectAggregate/ProjectConstructor.cs
+++ b/sample/tests/NimblePros.SampleToDo.UnitTests/Core/ProjectAggregate/ProjectConstructor.cs
@@ -1,5 +1,4 @@
 ﻿using NimblePros.SampleToDo.Core.ProjectAggregate;
-using Xunit;
 
 namespace NimblePros.SampleToDo.UnitTests.Core.ProjectAggregate;
 

--- a/sample/tests/NimblePros.SampleToDo.UnitTests/Core/ProjectAggregate/Project_AddItem.cs
+++ b/sample/tests/NimblePros.SampleToDo.UnitTests/Core/ProjectAggregate/Project_AddItem.cs
@@ -1,5 +1,4 @@
 ﻿using NimblePros.SampleToDo.Core.ProjectAggregate;
-using Xunit;
 
 namespace NimblePros.SampleToDo.UnitTests.Core.ProjectAggregate;
 

--- a/sample/tests/NimblePros.SampleToDo.UnitTests/Core/ProjectAggregate/ToDoItemMarkComplete.cs
+++ b/sample/tests/NimblePros.SampleToDo.UnitTests/Core/ProjectAggregate/ToDoItemMarkComplete.cs
@@ -1,5 +1,4 @@
 ﻿using NimblePros.SampleToDo.Core.ProjectAggregate.Events;
-using Xunit;
 
 namespace NimblePros.SampleToDo.UnitTests.Core.ProjectAggregate;
 

--- a/sample/tests/NimblePros.SampleToDo.UnitTests/Core/Services/DeleteContributorSevice_DeleteContributor.cs
+++ b/sample/tests/NimblePros.SampleToDo.UnitTests/Core/Services/DeleteContributorSevice_DeleteContributor.cs
@@ -1,10 +1,5 @@
 ﻿using NimblePros.SampleToDo.Core.ContributorAggregate;
 using NimblePros.SampleToDo.Core.Services;
-using Ardalis.SharedKernel;
-using MediatR;
-using Xunit;
-using Microsoft.Extensions.Logging;
-using NSubstitute;
 
 namespace NimblePros.SampleToDo.UnitTests.Core.Services;
 

--- a/sample/tests/NimblePros.SampleToDo.UnitTests/Core/Services/ToDoItemSearchServiceTests.cs
+++ b/sample/tests/NimblePros.SampleToDo.UnitTests/Core/Services/ToDoItemSearchServiceTests.cs
@@ -1,11 +1,6 @@
-﻿using Ardalis.Result;
-using Ardalis.Specification;
-using NimblePros.SampleToDo.Core.Interfaces;
+﻿using NimblePros.SampleToDo.Core.Interfaces;
 using NimblePros.SampleToDo.Core.ProjectAggregate;
 using NimblePros.SampleToDo.Core.Services;
-using Ardalis.SharedKernel;
-using Xunit;
-using NSubstitute;
 
 namespace NimblePros.SampleToDo.UnitTests.Core.Services;
 

--- a/sample/tests/NimblePros.SampleToDo.UnitTests/Core/Specifications/IncompleteItemSpecificationsConstructor.cs
+++ b/sample/tests/NimblePros.SampleToDo.UnitTests/Core/Specifications/IncompleteItemSpecificationsConstructor.cs
@@ -1,6 +1,5 @@
 ﻿using NimblePros.SampleToDo.Core.ProjectAggregate;
 using NimblePros.SampleToDo.Core.ProjectAggregate.Specifications;
-using Xunit;
 
 namespace NimblePros.SampleToDo.UnitTests.Core.Specifications;
 

--- a/sample/tests/NimblePros.SampleToDo.UnitTests/GlobalUsings.cs
+++ b/sample/tests/NimblePros.SampleToDo.UnitTests/GlobalUsings.cs
@@ -1,0 +1,10 @@
+﻿global using System.Runtime.CompilerServices;
+global using Ardalis.Result;
+global using Ardalis.SharedKernel;
+global using Ardalis.Specification;
+global using FluentAssertions;
+global using MediatR;
+global using Microsoft.Extensions.Logging;
+global using NSubstitute;
+global using NSubstitute.ReturnsExtensions;
+global using Xunit;

--- a/sample/tests/NimblePros.SampleToDo.UnitTests/NoOpMediator.cs
+++ b/sample/tests/NimblePros.SampleToDo.UnitTests/NoOpMediator.cs
@@ -1,7 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-using MediatR;
-
-namespace NimblePros.SampleToDo.UnitTests;
+﻿namespace NimblePros.SampleToDo.UnitTests;
 
 public class NoOpMediator : IMediator
 {

--- a/sample/tests/NimblePros.SampleToDo.UnitTests/UseCases/Contributors/CreateContributorHandlerHandle.cs
+++ b/sample/tests/NimblePros.SampleToDo.UnitTests/UseCases/Contributors/CreateContributorHandlerHandle.cs
@@ -1,9 +1,5 @@
-﻿using Ardalis.SharedKernel;
-using FluentAssertions;
-using NimblePros.SampleToDo.Core.ContributorAggregate;
+﻿using NimblePros.SampleToDo.Core.ContributorAggregate;
 using NimblePros.SampleToDo.UseCases.Contributors.Commands.Create;
-using NSubstitute;
-using Xunit;
 
 namespace NimblePros.SampleToDo.UnitTests.UseCases.Contributors;
 public class CreateContributorHandlerHandle

--- a/sample/tests/NimblePros.SampleToDo.UnitTests/UseCases/Contributors/GetContributorHandlerHandle.cs
+++ b/sample/tests/NimblePros.SampleToDo.UnitTests/UseCases/Contributors/GetContributorHandlerHandle.cs
@@ -1,12 +1,6 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-using FluentAssertions;
-using NimblePros.SampleToDo.Core.ContributorAggregate;
+﻿using NimblePros.SampleToDo.Core.ContributorAggregate;
 using NimblePros.SampleToDo.Core.ContributorAggregate.Specifications;
 using NimblePros.SampleToDo.UseCases.Contributors.Queries.Get;
-using NSubstitute;
-using NSubstitute.ReturnsExtensions;
-using Xunit;
 
 namespace NimblePros.SampleToDo.UnitTests.UseCases.Contributors;
 

--- a/sample/tests/NimblePros.SampleToDo.UnitTests/UseCases/Contributors/UpdateContributorHandlerHandle.cs
+++ b/sample/tests/NimblePros.SampleToDo.UnitTests/UseCases/Contributors/UpdateContributorHandlerHandle.cs
@@ -1,13 +1,5 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-using Ardalis.Specification;
-using FluentAssertions;
-using NimblePros.SampleToDo.Core.ContributorAggregate;
-using NimblePros.SampleToDo.Core.ContributorAggregate.Specifications;
+﻿using NimblePros.SampleToDo.Core.ContributorAggregate;
 using NimblePros.SampleToDo.UseCases.Contributors.Commands.Update;
-using NSubstitute;
-using NSubstitute.ReturnsExtensions;
-using Xunit;
 
 namespace NimblePros.SampleToDo.UnitTests.UseCases.Contributors;
 

--- a/src/Clean.Architecture.Core/ContributorAggregate/Contributor.cs
+++ b/src/Clean.Architecture.Core/ContributorAggregate/Contributor.cs
@@ -1,7 +1,4 @@
-﻿using Ardalis.GuardClauses;
-using Ardalis.SharedKernel;
-
-namespace Clean.Architecture.Core.ContributorAggregate;
+﻿namespace Clean.Architecture.Core.ContributorAggregate;
 
 public class Contributor(string name) : EntityBase, IAggregateRoot
 {

--- a/src/Clean.Architecture.Core/ContributorAggregate/ContributorStatus.cs
+++ b/src/Clean.Architecture.Core/ContributorAggregate/ContributorStatus.cs
@@ -1,6 +1,4 @@
-﻿using Ardalis.SmartEnum;
-
-namespace Clean.Architecture.Core.ContributorAggregate;
+﻿namespace Clean.Architecture.Core.ContributorAggregate;
 
 public class ContributorStatus : SmartEnum<ContributorStatus>
 {

--- a/src/Clean.Architecture.Core/ContributorAggregate/Events/ContributorDeletedEvent.cs
+++ b/src/Clean.Architecture.Core/ContributorAggregate/Events/ContributorDeletedEvent.cs
@@ -1,6 +1,4 @@
-﻿using Ardalis.SharedKernel;
-
-namespace Clean.Architecture.Core.ContributorAggregate.Events;
+﻿namespace Clean.Architecture.Core.ContributorAggregate.Events;
 
 /// <summary>
 /// A domain event that is dispatched whenever a contributor is deleted.

--- a/src/Clean.Architecture.Core/ContributorAggregate/Handlers/ContributorDeletedHandler.cs
+++ b/src/Clean.Architecture.Core/ContributorAggregate/Handlers/ContributorDeletedHandler.cs
@@ -1,7 +1,5 @@
 ﻿using Clean.Architecture.Core.ContributorAggregate.Events;
 using Clean.Architecture.Core.Interfaces;
-using MediatR;
-using Microsoft.Extensions.Logging;
 
 namespace Clean.Architecture.Core.ContributorAggregate.Handlers;
 

--- a/src/Clean.Architecture.Core/ContributorAggregate/Specifications/ContributorByIdSpec.cs
+++ b/src/Clean.Architecture.Core/ContributorAggregate/Specifications/ContributorByIdSpec.cs
@@ -1,6 +1,4 @@
-﻿using Ardalis.Specification;
-
-namespace Clean.Architecture.Core.ContributorAggregate.Specifications;
+﻿namespace Clean.Architecture.Core.ContributorAggregate.Specifications;
 
 public class ContributorByIdSpec : Specification<Contributor>
 {

--- a/src/Clean.Architecture.Core/GlobalUsings.cs
+++ b/src/Clean.Architecture.Core/GlobalUsings.cs
@@ -1,0 +1,7 @@
+﻿global using Ardalis.GuardClauses;
+global using Ardalis.Result;
+global using Ardalis.SharedKernel;
+global using Ardalis.SmartEnum;
+global using Ardalis.Specification;
+global using MediatR;
+global using Microsoft.Extensions.Logging;

--- a/src/Clean.Architecture.Core/Interfaces/IDeleteContributorService.cs
+++ b/src/Clean.Architecture.Core/Interfaces/IDeleteContributorService.cs
@@ -1,6 +1,4 @@
-﻿using Ardalis.Result;
-
-namespace Clean.Architecture.Core.Interfaces;
+﻿namespace Clean.Architecture.Core.Interfaces;
 
 public interface IDeleteContributorService
 {

--- a/src/Clean.Architecture.Core/Services/DeleteContributorService.cs
+++ b/src/Clean.Architecture.Core/Services/DeleteContributorService.cs
@@ -1,10 +1,7 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-using Clean.Architecture.Core.ContributorAggregate;
+﻿using Clean.Architecture.Core.ContributorAggregate;
 using Clean.Architecture.Core.ContributorAggregate.Events;
 using Clean.Architecture.Core.Interfaces;
-using MediatR;
-using Microsoft.Extensions.Logging;
+
 
 namespace Clean.Architecture.Core.Services;
 

--- a/src/Clean.Architecture.Infrastructure/Data/AppDbContext.cs
+++ b/src/Clean.Architecture.Infrastructure/Data/AppDbContext.cs
@@ -1,7 +1,4 @@
-﻿using System.Reflection;
-using Ardalis.SharedKernel;
-using Clean.Architecture.Core.ContributorAggregate;
-using Microsoft.EntityFrameworkCore;
+﻿using Clean.Architecture.Core.ContributorAggregate;
 
 namespace Clean.Architecture.Infrastructure.Data;
 public class AppDbContext(DbContextOptions<AppDbContext> options,

--- a/src/Clean.Architecture.Infrastructure/Data/AppDbContextExtensions.cs
+++ b/src/Clean.Architecture.Infrastructure/Data/AppDbContextExtensions.cs
@@ -1,7 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
-
-namespace Clean.Architecture.Infrastructure.Data;
+﻿namespace Clean.Architecture.Infrastructure.Data;
 
 public static class AppDbContextExtensions
 {

--- a/src/Clean.Architecture.Infrastructure/Data/Config/ContributorConfiguration.cs
+++ b/src/Clean.Architecture.Infrastructure/Data/Config/ContributorConfiguration.cs
@@ -1,6 +1,4 @@
 ﻿using Clean.Architecture.Core.ContributorAggregate;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Clean.Architecture.Infrastructure.Data.Config;
 

--- a/src/Clean.Architecture.Infrastructure/Data/EfRepository.cs
+++ b/src/Clean.Architecture.Infrastructure/Data/EfRepository.cs
@@ -1,7 +1,4 @@
-﻿using Ardalis.SharedKernel;
-using Ardalis.Specification.EntityFrameworkCore;
-
-namespace Clean.Architecture.Infrastructure.Data;
+﻿namespace Clean.Architecture.Infrastructure.Data;
 
 // inherit from Ardalis.Specification type
 public class EfRepository<T>(AppDbContext dbContext) :

--- a/src/Clean.Architecture.Infrastructure/Data/Queries/ListContributorsQueryService.cs
+++ b/src/Clean.Architecture.Infrastructure/Data/Queries/ListContributorsQueryService.cs
@@ -1,6 +1,5 @@
 ﻿using Clean.Architecture.UseCases.Contributors;
 using Clean.Architecture.UseCases.Contributors.List;
-using Microsoft.EntityFrameworkCore;
 
 namespace Clean.Architecture.Infrastructure.Data.Queries;
 

--- a/src/Clean.Architecture.Infrastructure/Data/SeedData.cs
+++ b/src/Clean.Architecture.Infrastructure/Data/SeedData.cs
@@ -1,5 +1,4 @@
 ﻿using Clean.Architecture.Core.ContributorAggregate;
-using Microsoft.EntityFrameworkCore;
 
 namespace Clean.Architecture.Infrastructure.Data;
 

--- a/src/Clean.Architecture.Infrastructure/Email/FakeEmailSender.cs
+++ b/src/Clean.Architecture.Infrastructure/Email/FakeEmailSender.cs
@@ -1,5 +1,4 @@
 ﻿using Clean.Architecture.Core.Interfaces;
-using Microsoft.Extensions.Logging;
 
 namespace Clean.Architecture.Infrastructure.Email;
 

--- a/src/Clean.Architecture.Infrastructure/Email/MimeKitEmailSender.cs
+++ b/src/Clean.Architecture.Infrastructure/Email/MimeKitEmailSender.cs
@@ -1,8 +1,4 @@
 ﻿using Clean.Architecture.Core.Interfaces;
-using MailKit.Net.Smtp;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using MimeKit;
 
 namespace Clean.Architecture.Infrastructure.Email;
 
@@ -16,7 +12,7 @@ public class MimeKitEmailSender(ILogger<MimeKitEmailSender> logger,
   {
     _logger.LogWarning("Sending email to {to} from {from} with subject {subject} using {type}.", to, from, subject, this.ToString());
 
-    using var client = new SmtpClient(); 
+    using var client = new MailKit.Net.Smtp.SmtpClient(); 
     await client.ConnectAsync(_mailserverConfiguration.Hostname, 
       _mailserverConfiguration.Port, false);
     var message = new MimeMessage();

--- a/src/Clean.Architecture.Infrastructure/Email/SmtpEmailSender.cs
+++ b/src/Clean.Architecture.Infrastructure/Email/SmtpEmailSender.cs
@@ -1,7 +1,4 @@
-﻿using System.Net.Mail;
-using Clean.Architecture.Core.Interfaces;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
+﻿using Clean.Architecture.Core.Interfaces;
 
 namespace Clean.Architecture.Infrastructure.Email;
 
@@ -17,7 +14,7 @@ public class SmtpEmailSender(ILogger<SmtpEmailSender> logger,
 
   public async Task SendEmailAsync(string to, string from, string subject, string body)
   {
-    var emailClient = new SmtpClient(_mailserverConfiguration.Hostname, _mailserverConfiguration.Port);
+    var emailClient = new System.Net.Mail.SmtpClient(_mailserverConfiguration.Hostname, _mailserverConfiguration.Port);
 
     var message = new MailMessage
     {

--- a/src/Clean.Architecture.Infrastructure/GlobalUsings.cs
+++ b/src/Clean.Architecture.Infrastructure/GlobalUsings.cs
@@ -1,0 +1,13 @@
+﻿global using System.Net.Mail;
+global using System.Reflection;
+global using Ardalis.GuardClauses;
+global using Ardalis.SharedKernel;
+global using Ardalis.Specification.EntityFrameworkCore;
+global using MailKit.Net.Smtp;
+global using Microsoft.EntityFrameworkCore;
+global using Microsoft.EntityFrameworkCore.Metadata.Builders;
+global using Microsoft.Extensions.Configuration;
+global using Microsoft.Extensions.DependencyInjection;
+global using Microsoft.Extensions.Logging;
+global using Microsoft.Extensions.Options;
+global using MimeKit;

--- a/src/Clean.Architecture.Infrastructure/InfrastructureServiceExtensions.cs
+++ b/src/Clean.Architecture.Infrastructure/InfrastructureServiceExtensions.cs
@@ -1,14 +1,9 @@
-﻿using Ardalis.GuardClauses;
-using Ardalis.SharedKernel;
-using Clean.Architecture.Core.Interfaces;
+﻿using Clean.Architecture.Core.Interfaces;
 using Clean.Architecture.Core.Services;
 using Clean.Architecture.Infrastructure.Data;
 using Clean.Architecture.Infrastructure.Data.Queries;
 using Clean.Architecture.UseCases.Contributors.List;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
+
 
 namespace Clean.Architecture.Infrastructure;
 public static class InfrastructureServiceExtensions

--- a/src/Clean.Architecture.UseCases/Contributors/Create/CreateContributorCommand.cs
+++ b/src/Clean.Architecture.UseCases/Contributors/Create/CreateContributorCommand.cs
@@ -1,6 +1,4 @@
-﻿using Ardalis.Result;
-
-namespace Clean.Architecture.UseCases.Contributors.Create;
+﻿namespace Clean.Architecture.UseCases.Contributors.Create;
 
 /// <summary>
 /// Create a new Contributor.

--- a/src/Clean.Architecture.UseCases/Contributors/Create/CreateContributorHandler.cs
+++ b/src/Clean.Architecture.UseCases/Contributors/Create/CreateContributorHandler.cs
@@ -1,6 +1,4 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-using Clean.Architecture.Core.ContributorAggregate;
+﻿using Clean.Architecture.Core.ContributorAggregate;
 
 namespace Clean.Architecture.UseCases.Contributors.Create;
 

--- a/src/Clean.Architecture.UseCases/Contributors/Delete/DeleteContributorCommand.cs
+++ b/src/Clean.Architecture.UseCases/Contributors/Delete/DeleteContributorCommand.cs
@@ -1,6 +1,3 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-
-namespace Clean.Architecture.UseCases.Contributors.Delete;
+﻿namespace Clean.Architecture.UseCases.Contributors.Delete;
 
 public record DeleteContributorCommand(int ContributorId) : ICommand<Result>;

--- a/src/Clean.Architecture.UseCases/Contributors/Delete/DeleteContributorHandler.cs
+++ b/src/Clean.Architecture.UseCases/Contributors/Delete/DeleteContributorHandler.cs
@@ -1,6 +1,4 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-using Clean.Architecture.Core.Interfaces;
+﻿using Clean.Architecture.Core.Interfaces;
 
 namespace Clean.Architecture.UseCases.Contributors.Delete;
 

--- a/src/Clean.Architecture.UseCases/Contributors/Get/GetContributorHandler.cs
+++ b/src/Clean.Architecture.UseCases/Contributors/Get/GetContributorHandler.cs
@@ -1,6 +1,4 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-using Clean.Architecture.Core.ContributorAggregate;
+﻿using Clean.Architecture.Core.ContributorAggregate;
 using Clean.Architecture.Core.ContributorAggregate.Specifications;
 
 namespace Clean.Architecture.UseCases.Contributors.Get;

--- a/src/Clean.Architecture.UseCases/Contributors/Get/GetContributorQuery.cs
+++ b/src/Clean.Architecture.UseCases/Contributors/Get/GetContributorQuery.cs
@@ -1,6 +1,3 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-
-namespace Clean.Architecture.UseCases.Contributors.Get;
+﻿namespace Clean.Architecture.UseCases.Contributors.Get;
 
 public record GetContributorQuery(int ContributorId) : IQuery<Result<ContributorDTO>>;

--- a/src/Clean.Architecture.UseCases/Contributors/List/ListContributorsHandler.cs
+++ b/src/Clean.Architecture.UseCases/Contributors/List/ListContributorsHandler.cs
@@ -1,7 +1,4 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-
-namespace Clean.Architecture.UseCases.Contributors.List;
+﻿namespace Clean.Architecture.UseCases.Contributors.List;
 
 public class ListContributorsHandler(IListContributorsQueryService _query)
   : IQueryHandler<ListContributorsQuery, Result<IEnumerable<ContributorDTO>>>

--- a/src/Clean.Architecture.UseCases/Contributors/List/ListContributorsQuery.cs
+++ b/src/Clean.Architecture.UseCases/Contributors/List/ListContributorsQuery.cs
@@ -1,6 +1,3 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-
-namespace Clean.Architecture.UseCases.Contributors.List;
+﻿namespace Clean.Architecture.UseCases.Contributors.List;
 
 public record ListContributorsQuery(int? Skip, int? Take) : IQuery<Result<IEnumerable<ContributorDTO>>>;

--- a/src/Clean.Architecture.UseCases/Contributors/Update/UpdateContributorCommand.cs
+++ b/src/Clean.Architecture.UseCases/Contributors/Update/UpdateContributorCommand.cs
@@ -1,6 +1,3 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-
-namespace Clean.Architecture.UseCases.Contributors.Update;
+﻿namespace Clean.Architecture.UseCases.Contributors.Update;
 
 public record UpdateContributorCommand(int ContributorId, string NewName) : ICommand<Result<ContributorDTO>>;

--- a/src/Clean.Architecture.UseCases/Contributors/Update/UpdateContributorHandler.cs
+++ b/src/Clean.Architecture.UseCases/Contributors/Update/UpdateContributorHandler.cs
@@ -1,6 +1,4 @@
-﻿using Ardalis.Result;
-using Ardalis.SharedKernel;
-using Clean.Architecture.Core.ContributorAggregate;
+﻿using Clean.Architecture.Core.ContributorAggregate;
 
 namespace Clean.Architecture.UseCases.Contributors.Update;
 

--- a/src/Clean.Architecture.UseCases/GlobalUsings.cs
+++ b/src/Clean.Architecture.UseCases/GlobalUsings.cs
@@ -1,0 +1,2 @@
+﻿global using Ardalis.Result;
+global using Ardalis.SharedKernel;

--- a/src/Clean.Architecture.Web/Configurations/OptionConfigs.cs
+++ b/src/Clean.Architecture.Web/Configurations/OptionConfigs.cs
@@ -5,7 +5,7 @@ namespace Clean.Architecture.Web.Configurations;
 
 public static class OptionConfigs
 {
-  public static IServiceCollection AddOptionConfigs(this IServiceCollection services,IConfiguration configuration,ILogger logger, WebApplicationBuilder builder)
+  public static IServiceCollection AddOptionConfigs(this IServiceCollection services,IConfiguration configuration,Microsoft.Extensions.Logging.ILogger logger, WebApplicationBuilder builder)
   {
     services.Configure<MailserverConfiguration>(configuration.GetSection("Mailserver"))
     // Configure Web Behavior

--- a/src/Clean.Architecture.Web/Configurations/ServiceConfigs.cs
+++ b/src/Clean.Architecture.Web/Configurations/ServiceConfigs.cs
@@ -6,7 +6,7 @@ namespace Clean.Architecture.Web.Configurations;
 
 public static class ServiceConfigs
 {
-  public static IServiceCollection AddServiceConfigs(this IServiceCollection services, ILogger logger, WebApplicationBuilder builder)
+  public static IServiceCollection AddServiceConfigs(this IServiceCollection services, Microsoft.Extensions.Logging.ILogger logger, WebApplicationBuilder builder)
   {
     services.AddInfrastructureServices(builder.Configuration, logger)
             .AddMediatrConfigs();

--- a/src/Clean.Architecture.Web/Contributors/Create.cs
+++ b/src/Clean.Architecture.Web/Contributors/Create.cs
@@ -1,6 +1,4 @@
 ﻿using Clean.Architecture.UseCases.Contributors.Create;
-using FastEndpoints;
-using MediatR;
 
 namespace Clean.Architecture.Web.Contributors;
 

--- a/src/Clean.Architecture.Web/Contributors/Delete.cs
+++ b/src/Clean.Architecture.Web/Contributors/Delete.cs
@@ -1,7 +1,4 @@
-﻿using Ardalis.Result;
-using Clean.Architecture.UseCases.Contributors.Delete;
-using FastEndpoints;
-using MediatR;
+﻿using Clean.Architecture.UseCases.Contributors.Delete;
 
 namespace Clean.Architecture.Web.Contributors;
 

--- a/src/Clean.Architecture.Web/Contributors/GetById.cs
+++ b/src/Clean.Architecture.Web/Contributors/GetById.cs
@@ -1,7 +1,4 @@
-﻿using Ardalis.Result;
-using Clean.Architecture.UseCases.Contributors.Get;
-using FastEndpoints;
-using MediatR;
+﻿using Clean.Architecture.UseCases.Contributors.Get;
 
 namespace Clean.Architecture.Web.Contributors;
 

--- a/src/Clean.Architecture.Web/Contributors/List.cs
+++ b/src/Clean.Architecture.Web/Contributors/List.cs
@@ -1,8 +1,5 @@
-﻿using Ardalis.Result;
-using Clean.Architecture.UseCases.Contributors;
+﻿using Clean.Architecture.UseCases.Contributors;
 using Clean.Architecture.UseCases.Contributors.List;
-using FastEndpoints;
-using MediatR;
 
 namespace Clean.Architecture.Web.Contributors;
 

--- a/src/Clean.Architecture.Web/Contributors/Update.cs
+++ b/src/Clean.Architecture.Web/Contributors/Update.cs
@@ -1,8 +1,5 @@
-﻿using Ardalis.Result;
-using Clean.Architecture.UseCases.Contributors.Get;
+﻿using Clean.Architecture.UseCases.Contributors.Get;
 using Clean.Architecture.UseCases.Contributors.Update;
-using FastEndpoints;
-using MediatR;
 
 namespace Clean.Architecture.Web.Contributors;
 

--- a/src/Clean.Architecture.Web/GlobalUsings.cs
+++ b/src/Clean.Architecture.Web/GlobalUsings.cs
@@ -1,0 +1,6 @@
+﻿global using FastEndpoints;
+global using FastEndpoints.Swagger;
+global using MediatR;
+global using Serilog;
+global using Serilog.Extensions.Logging;
+global using Ardalis.Result;

--- a/src/Clean.Architecture.Web/Program.cs
+++ b/src/Clean.Architecture.Web/Program.cs
@@ -1,9 +1,4 @@
 ﻿using Clean.Architecture.Web.Configurations;
-using FastEndpoints;
-using FastEndpoints.Swagger;
-using Serilog;
-using Serilog.Extensions.Logging;
-
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/tests/Clean.Architecture.FunctionalTests/ApiEndpoints/ContributorGetById.cs
+++ b/tests/Clean.Architecture.FunctionalTests/ApiEndpoints/ContributorGetById.cs
@@ -1,7 +1,6 @@
-﻿using Ardalis.HttpClientTestExtensions;
-using Clean.Architecture.Infrastructure.Data;
+﻿using Clean.Architecture.Infrastructure.Data;
 using Clean.Architecture.Web.Contributors;
-using Xunit;
+
 
 namespace Clean.Architecture.FunctionalTests.ApiEndpoints;
 

--- a/tests/Clean.Architecture.FunctionalTests/ApiEndpoints/ContributorList.cs
+++ b/tests/Clean.Architecture.FunctionalTests/ApiEndpoints/ContributorList.cs
@@ -1,7 +1,5 @@
-﻿using Ardalis.HttpClientTestExtensions;
-using Clean.Architecture.Infrastructure.Data;
+﻿using Clean.Architecture.Infrastructure.Data;
 using Clean.Architecture.Web.Contributors;
-using Xunit;
 
 namespace Clean.Architecture.FunctionalTests.ApiEndpoints;
 

--- a/tests/Clean.Architecture.FunctionalTests/CustomWebApplicationFactory.cs
+++ b/tests/Clean.Architecture.FunctionalTests/CustomWebApplicationFactory.cs
@@ -1,9 +1,4 @@
 ﻿using Clean.Architecture.Infrastructure.Data;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace Clean.Architecture.FunctionalTests;
 

--- a/tests/Clean.Architecture.FunctionalTests/GlobalUsings.cs
+++ b/tests/Clean.Architecture.FunctionalTests/GlobalUsings.cs
@@ -1,0 +1,7 @@
+﻿global using Ardalis.HttpClientTestExtensions;
+global using Microsoft.AspNetCore.Hosting;
+global using Microsoft.AspNetCore.Mvc.Testing;
+global using Microsoft.Extensions.DependencyInjection;
+global using Microsoft.Extensions.Hosting;
+global using Microsoft.Extensions.Logging;
+global using Xunit;

--- a/tests/Clean.Architecture.IntegrationTests/Data/BaseEfRepoTestFixture.cs
+++ b/tests/Clean.Architecture.IntegrationTests/Data/BaseEfRepoTestFixture.cs
@@ -1,9 +1,5 @@
-﻿using Ardalis.SharedKernel;
-using Clean.Architecture.Core.ContributorAggregate;
+﻿using Clean.Architecture.Core.ContributorAggregate;
 using Clean.Architecture.Infrastructure.Data;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
-using NSubstitute;
 
 namespace Clean.Architecture.IntegrationTests.Data;
 

--- a/tests/Clean.Architecture.IntegrationTests/Data/EfRepositoryAdd.cs
+++ b/tests/Clean.Architecture.IntegrationTests/Data/EfRepositoryAdd.cs
@@ -1,5 +1,4 @@
 ﻿using Clean.Architecture.Core.ContributorAggregate;
-using Xunit;
 
 namespace Clean.Architecture.IntegrationTests.Data;
 

--- a/tests/Clean.Architecture.IntegrationTests/Data/EfRepositoryDelete.cs
+++ b/tests/Clean.Architecture.IntegrationTests/Data/EfRepositoryDelete.cs
@@ -1,5 +1,4 @@
 ﻿using Clean.Architecture.Core.ContributorAggregate;
-using Xunit;
 
 namespace Clean.Architecture.IntegrationTests.Data;
 

--- a/tests/Clean.Architecture.IntegrationTests/Data/EfRepositoryUpdate.cs
+++ b/tests/Clean.Architecture.IntegrationTests/Data/EfRepositoryUpdate.cs
@@ -1,6 +1,5 @@
 ﻿using Clean.Architecture.Core.ContributorAggregate;
-using Microsoft.EntityFrameworkCore;
-using Xunit;
+
 
 namespace Clean.Architecture.IntegrationTests.Data;
 

--- a/tests/Clean.Architecture.IntegrationTests/GlobalUsings.cs
+++ b/tests/Clean.Architecture.IntegrationTests/GlobalUsings.cs
@@ -1,0 +1,5 @@
+﻿global using Ardalis.SharedKernel;
+global using Microsoft.EntityFrameworkCore;
+global using Microsoft.Extensions.DependencyInjection;
+global using NSubstitute;
+global using Xunit;

--- a/tests/Clean.Architecture.UnitTests/Core/ContributorAggregate/ContributorConstructor.cs
+++ b/tests/Clean.Architecture.UnitTests/Core/ContributorAggregate/ContributorConstructor.cs
@@ -1,7 +1,4 @@
-﻿using Clean.Architecture.Core.ContributorAggregate;
-using Xunit;
-
-namespace Clean.Architecture.UnitTests.Core.ContributorAggregate;
+﻿namespace Clean.Architecture.UnitTests.Core.ContributorAggregate;
 
 public class ContributorConstructor
 {

--- a/tests/Clean.Architecture.UnitTests/Core/Services/DeleteContributorSevice_DeleteContributor.cs
+++ b/tests/Clean.Architecture.UnitTests/Core/Services/DeleteContributorSevice_DeleteContributor.cs
@@ -1,10 +1,4 @@
-﻿using Ardalis.SharedKernel;
-using Clean.Architecture.Core.ContributorAggregate;
-using Clean.Architecture.Core.Services;
-using MediatR;
-using Microsoft.Extensions.Logging;
-using NSubstitute;
-using Xunit;
+﻿using Clean.Architecture.Core.Services;
 
 namespace Clean.Architecture.UnitTests.Core.Services;
 

--- a/tests/Clean.Architecture.UnitTests/GlobalUsings.cs
+++ b/tests/Clean.Architecture.UnitTests/GlobalUsings.cs
@@ -1,0 +1,9 @@
+﻿global using System.Runtime.CompilerServices;
+global using Ardalis.SharedKernel;
+global using Clean.Architecture.Core.ContributorAggregate;
+global using Clean.Architecture.UseCases.Contributors.Create;
+global using FluentAssertions;
+global using MediatR;
+global using Microsoft.Extensions.Logging;
+global using NSubstitute;
+global using Xunit;

--- a/tests/Clean.Architecture.UnitTests/NoOpMediator.cs
+++ b/tests/Clean.Architecture.UnitTests/NoOpMediator.cs
@@ -1,7 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-using MediatR;
-
-namespace Clean.Architecture.UnitTests;
+﻿namespace Clean.Architecture.UnitTests;
 
 public class NoOpMediator : IMediator
 {

--- a/tests/Clean.Architecture.UnitTests/UseCases/Contributors/CreateContributorHandlerHandle.cs
+++ b/tests/Clean.Architecture.UnitTests/UseCases/Contributors/CreateContributorHandlerHandle.cs
@@ -1,11 +1,4 @@
-﻿using Ardalis.SharedKernel;
-using Clean.Architecture.Core.ContributorAggregate;
-using Clean.Architecture.UseCases.Contributors.Create;
-using FluentAssertions;
-using NSubstitute;
-using Xunit;
-
-namespace Clean.Architecture.UnitTests.UseCases.Contributors;
+﻿namespace Clean.Architecture.UnitTests.UseCases.Contributors;
 
 public class CreateContributorHandlerHandle
 {


### PR DESCRIPTION
All projects have been unified for  "GlobalUsing"; based on the implementation of the sample project.
https://github.com/ardalis/CleanArchitecture/commit/9db4a841ea934791593b599339a1776c6a1a1db6