### PR TITLE
Migrate from FluentAssertions to Shouldly

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,6 @@
     <PackageVersion Include="FastEndpoints.ApiExplorer" Version="2.2.0" />
     <PackageVersion Include="FastEndpoints.Swagger" Version="5.31.0" />
     <PackageVersion Include="FastEndpoints.Swagger.Swashbuckle" Version="2.2.0" />
-    <PackageVersion Include="FluentAssertions" Version="7.0.0" />
     <PackageVersion Include="MailKit" Version="4.9.0" />
     <PackageVersion Include="MediatR" Version="12.4.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
@@ -33,6 +32,7 @@
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="ReportGenerator" Version="5.4.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="SQLite" Version="3.13.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />

--- a/tests/Clean.Architecture.FunctionalTests/ApiEndpoints/ContributorGetById.cs
+++ b/tests/Clean.Architecture.FunctionalTests/ApiEndpoints/ContributorGetById.cs
@@ -14,8 +14,8 @@ public class ContributorGetById(CustomWebApplicationFactory<Program> factory) : 
   {
     var result = await _client.GetAndDeserializeAsync<ContributorRecord>(GetContributorByIdRequest.BuildRoute(1));
 
-    Assert.Equal(1, result.Id);
-    Assert.Equal(SeedData.Contributor1.Name, result.Name);
+    result.Id.ShouldBe(1);
+    result.Name.ShouldBe(SeedData.Contributor1.Name);
   }
 
   [Fact]

--- a/tests/Clean.Architecture.FunctionalTests/ApiEndpoints/ContributorList.cs
+++ b/tests/Clean.Architecture.FunctionalTests/ApiEndpoints/ContributorList.cs
@@ -13,8 +13,8 @@ public class ContributorList(CustomWebApplicationFactory<Program> factory) : ICl
   {
     var result = await _client.GetAndDeserializeAsync<ContributorListResponse>("/Contributors");
 
-    Assert.Equal(2, result.Contributors.Count);
-    Assert.Contains(result.Contributors, i => i.Name == SeedData.Contributor1.Name);
-    Assert.Contains(result.Contributors, i => i.Name == SeedData.Contributor2.Name);
+    result.Contributors.Count.ShouldBe(2);
+    result.Contributors.ShouldContain(contributor => contributor.Name == SeedData.Contributor1.Name);
+    result.Contributors.ShouldContain(contributor => contributor.Name == SeedData.Contributor2.Name);
   }
 }

--- a/tests/Clean.Architecture.FunctionalTests/Clean.Architecture.FunctionalTests.csproj
+++ b/tests/Clean.Architecture.FunctionalTests/Clean.Architecture.FunctionalTests.csproj
@@ -2,7 +2,7 @@
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Shouldly" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/tests/Clean.Architecture.FunctionalTests/GlobalUsings.cs
+++ b/tests/Clean.Architecture.FunctionalTests/GlobalUsings.cs
@@ -4,4 +4,5 @@ global using Microsoft.AspNetCore.Mvc.Testing;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Hosting;
 global using Microsoft.Extensions.Logging;
+global using Shouldly;
 global using Xunit;

--- a/tests/Clean.Architecture.IntegrationTests/Data/EfRepositoryAdd.cs
+++ b/tests/Clean.Architecture.IntegrationTests/Data/EfRepositoryAdd.cs
@@ -17,8 +17,9 @@ public class EfRepositoryAdd : BaseEfRepoTestFixture
     var newContributor = (await repository.ListAsync())
                     .FirstOrDefault();
 
-    Assert.Equal(testContributorName, newContributor?.Name);
-    Assert.Equal(testContributorStatus, newContributor?.Status);
-    Assert.True(newContributor?.Id > 0);
+    newContributor.ShouldNotBeNull();
+    testContributorName.ShouldBe(newContributor.Name);
+    testContributorStatus.ShouldBe(newContributor.Status);
+    newContributor.Id.ShouldBeGreaterThan(0);
   }
 }

--- a/tests/Clean.Architecture.IntegrationTests/Data/EfRepositoryDelete.cs
+++ b/tests/Clean.Architecture.IntegrationTests/Data/EfRepositoryDelete.cs
@@ -17,7 +17,6 @@ public class EfRepositoryDelete : BaseEfRepoTestFixture
     await repository.DeleteAsync(Contributor);
 
     // verify it's no longer there
-    Assert.DoesNotContain(await repository.ListAsync(),
-        Contributor => Contributor.Name == initialName);
+    (await repository.ListAsync()).ShouldNotContain(Contributor => Contributor.Name == initialName);
   }
 }

--- a/tests/Clean.Architecture.IntegrationTests/Data/EfRepositoryUpdate.cs
+++ b/tests/Clean.Architecture.IntegrationTests/Data/EfRepositoryUpdate.cs
@@ -1,6 +1,5 @@
 ﻿using Clean.Architecture.Core.ContributorAggregate;
 
-
 namespace Clean.Architecture.IntegrationTests.Data;
 
 public class EfRepositoryUpdate : BaseEfRepoTestFixture
@@ -23,10 +22,10 @@ public class EfRepositoryUpdate : BaseEfRepoTestFixture
         .FirstOrDefault(Contributor => Contributor.Name == initialName);
     if (newContributor == null)
     {
-      Assert.NotNull(newContributor);
+      newContributor.ShouldNotBeNull();
       return;
     }
-    Assert.NotSame(Contributor, newContributor);
+    Contributor.ShouldNotBeSameAs(newContributor);
     var newName = Guid.NewGuid().ToString();
     newContributor.UpdateName(newName);
 
@@ -37,9 +36,9 @@ public class EfRepositoryUpdate : BaseEfRepoTestFixture
     var updatedItem = (await repository.ListAsync())
         .FirstOrDefault(Contributor => Contributor.Name == newName);
 
-    Assert.NotNull(updatedItem);
-    Assert.NotEqual(Contributor.Name, updatedItem?.Name);
-    Assert.Equal(Contributor.Status, updatedItem?.Status);
-    Assert.Equal(newContributor.Id, updatedItem?.Id);
+    updatedItem.ShouldNotBeNull();
+    Contributor.Name.ShouldNotBe(updatedItem.Name);
+    Contributor.Status.ShouldBe(updatedItem.Status);
+    newContributor.Id.ShouldBe(updatedItem.Id);
   }
 }

--- a/tests/Clean.Architecture.IntegrationTests/Data/EfRepositoryUpdate.cs
+++ b/tests/Clean.Architecture.IntegrationTests/Data/EfRepositoryUpdate.cs
@@ -20,11 +20,8 @@ public class EfRepositoryUpdate : BaseEfRepoTestFixture
     // fetch the item and update its title
     var newContributor = (await repository.ListAsync())
         .FirstOrDefault(Contributor => Contributor.Name == initialName);
-    if (newContributor == null)
-    {
-      newContributor.ShouldNotBeNull();
-      return;
-    }
+    newContributor.ShouldNotBeNull();
+
     Contributor.ShouldNotBeSameAs(newContributor);
     var newName = Guid.NewGuid().ToString();
     newContributor.UpdateName(newName);

--- a/tests/Clean.Architecture.IntegrationTests/GlobalUsings.cs
+++ b/tests/Clean.Architecture.IntegrationTests/GlobalUsings.cs
@@ -2,4 +2,5 @@
 global using Microsoft.EntityFrameworkCore;
 global using Microsoft.Extensions.DependencyInjection;
 global using NSubstitute;
+global using Shouldly;
 global using Xunit;

--- a/tests/Clean.Architecture.UnitTests/Clean.Architecture.UnitTests.csproj
+++ b/tests/Clean.Architecture.UnitTests/Clean.Architecture.UnitTests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Shouldly" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/tests/Clean.Architecture.UnitTests/Core/ContributorAggregate/ContributorConstructor.cs
+++ b/tests/Clean.Architecture.UnitTests/Core/ContributorAggregate/ContributorConstructor.cs
@@ -15,6 +15,6 @@ public class ContributorConstructor
   {
     _testContributor = CreateContributor();
 
-    Assert.Equal(_testName, _testContributor.Name);
+    _testContributor.Name.ShouldBe(_testName);
   }
 }

--- a/tests/Clean.Architecture.UnitTests/Core/Services/DeleteContributorSevice_DeleteContributor.cs
+++ b/tests/Clean.Architecture.UnitTests/Core/Services/DeleteContributorSevice_DeleteContributor.cs
@@ -20,6 +20,6 @@ public class DeleteContributorService_DeleteContributor
   {
     var result = await _service.DeleteContributor(0);
 
-    Assert.Equal(Ardalis.Result.ResultStatus.NotFound, result.Status);
+    result.Status.ShouldBe(Ardalis.Result.ResultStatus.NotFound);
   }
 }

--- a/tests/Clean.Architecture.UnitTests/GlobalUsings.cs
+++ b/tests/Clean.Architecture.UnitTests/GlobalUsings.cs
@@ -2,7 +2,7 @@
 global using Ardalis.SharedKernel;
 global using Clean.Architecture.Core.ContributorAggregate;
 global using Clean.Architecture.UseCases.Contributors.Create;
-global using FluentAssertions;
+global using Shouldly;
 global using MediatR;
 global using Microsoft.Extensions.Logging;
 global using NSubstitute;

--- a/tests/Clean.Architecture.UnitTests/UseCases/Contributors/CreateContributorHandlerHandle.cs
+++ b/tests/Clean.Architecture.UnitTests/UseCases/Contributors/CreateContributorHandlerHandle.cs
@@ -23,6 +23,6 @@ public class CreateContributorHandlerHandle
       .Returns(Task.FromResult(CreateContributor()));
     var result = await _handler.Handle(new CreateContributorCommand(_testName, null), CancellationToken.None);
 
-    result.IsSuccess.Should().BeTrue();
+    result.IsSuccess.ShouldBeTrue();
   }
 }


### PR DESCRIPTION
Migrate from FluentAssertions to Shouldly.

- Removed all references to the Fluentassertions package.
- Added Shouldly and replaced all default assertions with the Shouldly syntax.

Fixes #911 