### PR TITLE
Adding the Microsoft.EntityFrameworkCore.Design references to the Web projects

### DIFF
--- a/sample/src/NimblePros.SampleToDo.Web/NimblePros.SampleToDo.Web.csproj
+++ b/sample/src/NimblePros.SampleToDo.Web/NimblePros.SampleToDo.Web.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="Mediator.SourceGenerator" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" PrivateAssets="all" />
     <PackageReference Include="NimblePros.Metronome" />
     <PackageReference Include="NimblePros.SharedKernel" />

--- a/src/Clean.Architecture.Web/Clean.Architecture.Web.csproj
+++ b/src/Clean.Architecture.Web/Clean.Architecture.Web.csproj
@@ -18,6 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" />
     <PackageReference Include="Scalar.AspNetCore" />
     <PackageReference Include="Serilog.AspNetCore" />
   </ItemGroup>


### PR DESCRIPTION
This adds Microsoft.EntityFrameworkCore.Design references to:

- sample's Web project
- template's Web project

This should close #984. 