### PR TITLE
Replace xUnit assertions with Shouldly.

### DIFF
--- a/tests/Clean.Architecture.FunctionalTests/ApiEndpoints/ContributorList.cs
+++ b/tests/Clean.Architecture.FunctionalTests/ApiEndpoints/ContributorList.cs
@@ -13,8 +13,8 @@ public class ContributorList(CustomWebApplicationFactory<Program> factory) : ICl
   {
     var result = await _client.GetAndDeserializeAsync<ContributorListResponse>("/Contributors");
 
-    Assert.Equal(SeedData.NUMBER_OF_CONTRIBUTORS, result.TotalCount);
-    Assert.Contains(result.Items, i => i.Name == SeedData.Contributor1Name.Value);
-    Assert.Contains(result.Items, i => i.Name == SeedData.Contributor2Name.Value);
+    result.TotalCount.ShouldBe(SeedData.NUMBER_OF_CONTRIBUTORS);
+    result.Items.ShouldContain(i => i.Name == SeedData.Contributor1Name.Value);
+    result.Items.ShouldContain(i => i.Name == SeedData.Contributor2Name.Value);
   }
 }

--- a/tests/Clean.Architecture.UnitTests/Core/ContributorAggregate/ContributorIdFrom.cs
+++ b/tests/Clean.Architecture.UnitTests/Core/ContributorAggregate/ContributorIdFrom.cs
@@ -7,7 +7,7 @@ public class ContributorIdFrom
   {
     int validValue = 1;
     var contributorId = ContributorId.From(validValue);
-    Assert.Equal(validValue, contributorId.Value);
+    contributorId.Value.ShouldBe(validValue);
   }
 
   [Theory]

--- a/tests/Clean.Architecture.UnitTests/Core/ContributorAggregate/ContributorNameFrom.cs
+++ b/tests/Clean.Architecture.UnitTests/Core/ContributorAggregate/ContributorNameFrom.cs
@@ -7,7 +7,7 @@ public class ContributorNameFrom
   {
     string validValue = "ardalis";
     var contributorName = ContributorName.From(validValue);
-    Assert.Equal(validValue, contributorName.Value);
+    contributorName.Value.ShouldBe(validValue);
   }
 
   [Theory]


### PR DESCRIPTION
Modified : tests/Clean.Architecture.FunctionalTests/ApiEndpoints/ContributorList.cs
Modified : tests/Clean.Architecture.UnitTests/Core/ContributorAggregate/ContributorIdFrom.cs
Modified : tests/Clean.Architecture.UnitTests/Core/ContributorAggregate/ContributorNameFrom.cs