### PR TITLE
Make SQLite fallback reliable when Docker is unavailable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,54 @@
 version: 2
+
 updates:
-- package-ecosystem: nuget
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+  - package-ecosystem: "nuget"
+    directory: "/"
+
+    schedule:
+      interval: "daily"
+      time: "16:45"
+      timezone: "Europe/Berlin"
+
+ 
+    open-pull-requests-limit: 10
+
+    groups:
+      microsoft-packages:
+        patterns:
+          - "Microsoft.*"
+        update-types:
+          - "minor"
+          - "patch"
+
+      test-packages:
+        patterns:
+          - "Microsoft.NET.Test.Sdk"
+          - "xunit*"
+          - "NUnit*"
+          - "coverlet*"
+          - "FluentAssertions"
+        update-types:
+          - "minor"
+          - "patch"
+
+      all-other-non-major:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "Microsoft.*"
+          - "Microsoft.NET.Test.Sdk"
+          - "xunit*"
+          - "NUnit*"
+          - "coverlet*"
+          - "FluentAssertions"
+        update-types:
+          - "minor"
+          - "patch"
+
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+    labels:
+      - "dependencies"
+      - "nuget"

--- a/.gitignore
+++ b/.gitignore
@@ -275,3 +275,4 @@ Packages.props
 #Local Log Files
 log*.txt
 /sample/src/NimblePros.SampleToDo.Web/appsettings.Development.json
+.localpilot/

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,11 @@ bld/
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
+# Local SonarQube Scanner working directory
+.sonarqube/
 
+# Visual Studio local workspace state
+.vs/
 # Hugo generated site output
 docs/public/
 

--- a/Clean.Architecture.slnx
+++ b/Clean.Architecture.slnx
@@ -6,12 +6,14 @@
   </Configurations>
   <Folder Name="/Solution Items/">
     <File Path=".editorconfig" />
+    <File Path=".gitignore" />
     <File Path=".template.config/template.json" />
     <File Path="CleanArchitecture.nuspec" />
     <File Path="Directory.Build.props" />
     <File Path="Directory.Packages.props" />
   </Folder>
   <Folder Name="/src/">
+    <File Path=".editorconfig" />
     <Project Path="src/Clean.Architecture.Core/Clean.Architecture.Core.csproj" />
     <Project Path="src/Clean.Architecture.Infrastructure/Clean.Architecture.Infrastructure.csproj" />
     <Project Path="src/Clean.Architecture.UseCases/Clean.Architecture.UseCases.csproj" />
@@ -22,6 +24,7 @@
     <Project Path="src/Clean.Architecture.ServiceDefaults/Clean.Architecture.ServiceDefaults.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <File Path="tests/.editorconfig" />
     <Project Path="tests/Clean.Architecture.FunctionalTests/Clean.Architecture.FunctionalTests.csproj">
       <BuildDependency Project="src/Clean.Architecture.Web/Clean.Architecture.Web.csproj" />
     </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,10 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <AnalysisMode>Recommended</AnalysisMode>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,6 +37,7 @@
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="SQLite" Version="3.13.0" />
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
     <PackageVersion Include="Testcontainers" Version="4.11.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="Ardalis.Specification" Version="9.3.1" />
     <PackageVersion Include="Ardalis.Specification.EntityFrameworkCore" Version="9.3.1" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
-    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="FastEndpoints" Version="8.1.0" />
     <PackageVersion Include="FastEndpoints.ApiExplorer" Version="2.2.0" />
     <PackageVersion Include="FastEndpoints.Swagger" Version="8.1.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="MessagePack" Version="3.1.8" />
     <PackageVersion Include="Mediator.Abstractions" Version="3.0.2" />
     <PackageVersion Include="Mediator.SourceGenerator" Version="3.0.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.10" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="NimblePros.Metronome" Version="0.4.1" />
     <PackageVersion Include="NSubstitute" Version="6.0.0" />
     <PackageVersion Include="ReportGenerator" Version="5.5.10" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.13" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.15" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
@@ -44,14 +44,14 @@
     <PackageVersion Include="Testcontainers.MsSql" Version="4.13.0" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.3.5" />
+    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.4.6" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.8.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
     <PackageVersion Include="Aspire.Hosting.Testing" Version="9.5.1" />
     <PackageVersion Include="Vogen" Version="8.0.6" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,11 +40,15 @@
     <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
-    <PackageVersion Include="Testcontainers" Version="4.11.0" />
-    <PackageVersion Include="Testcontainers.MsSql" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers" Version="4.13.0" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.13.0" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.3.5" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.8.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,9 +11,9 @@
     <PackageVersion Include="Ardalis.Specification.EntityFrameworkCore" Version="9.3.1" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
-    <PackageVersion Include="FastEndpoints" Version="8.1.0" />
+    <PackageVersion Include="FastEndpoints" Version="8.2.0" />
     <PackageVersion Include="FastEndpoints.ApiExplorer" Version="2.2.0" />
-    <PackageVersion Include="FastEndpoints.Swagger" Version="8.1.0" />
+    <PackageVersion Include="FastEndpoints.Swagger" Version="8.2.0" />
     <PackageVersion Include="MailKit" Version="4.17.0" />
     <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="Mediator.Abstractions" Version="3.0.2" />
@@ -31,8 +31,8 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="NimblePros.Metronome" Version="0.4.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="ReportGenerator" Version="5.5.9" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.4" />
+    <PackageVersion Include="ReportGenerator" Version="5.5.10" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.13" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
@@ -47,12 +47,12 @@
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.3.5" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.8.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.16.0" />
     <PackageVersion Include="Aspire.Hosting.Testing" Version="9.5.1" />
-    <PackageVersion Include="Vogen" Version="8.0.5" />
+    <PackageVersion Include="Vogen" Version="8.0.6" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,9 +30,9 @@
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="NimblePros.Metronome" Version="0.4.1" />
-    <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="ReportGenerator" Version="5.5.10" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.13" />
+    <PackageVersion Include="NSubstitute" Version="6.0.0" />
+    <PackageVersion Include="ReportGenerator" Version="5.5.9" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.4" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,14 +45,10 @@
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.3.5" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.8.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.16.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,13 +19,13 @@
     <PackageVersion Include="Mediator.Abstractions" Version="3.0.2" />
     <PackageVersion Include="Mediator.SourceGenerator" Version="3.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
@@ -45,8 +45,8 @@
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.3.5" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.8.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,11 +24,11 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="NimblePros.Metronome" Version="0.4.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="ReportGenerator" Version="5.5.9" />
@@ -45,8 +45,8 @@
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.3.5" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.8.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,12 +10,12 @@
     <PackageVersion Include="Ardalis.Specification" Version="9.3.1" />
     <PackageVersion Include="Ardalis.Specification.EntityFrameworkCore" Version="9.3.1" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
-    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="FastEndpoints" Version="8.2.0" />
     <PackageVersion Include="FastEndpoints.ApiExplorer" Version="2.2.0" />
     <PackageVersion Include="FastEndpoints.Swagger" Version="8.2.0" />
     <PackageVersion Include="MailKit" Version="4.17.0" />
-    <PackageVersion Include="MessagePack" Version="3.1.7" />
+    <PackageVersion Include="MessagePack" Version="3.1.8" />
     <PackageVersion Include="Mediator.Abstractions" Version="3.0.2" />
     <PackageVersion Include="Mediator.SourceGenerator" Version="3.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
@@ -30,9 +30,9 @@
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="NimblePros.Metronome" Version="0.4.1" />
-    <PackageVersion Include="NSubstitute" Version="6.0.0" />
-    <PackageVersion Include="ReportGenerator" Version="5.5.9" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.4" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="ReportGenerator" Version="5.5.10" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.13" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
@@ -45,8 +45,8 @@
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.3.5" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.8.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,7 @@
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="NimblePros.Metronome" Version="0.4.1" />
-    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="NSubstitute" Version="6.0.0" />
     <PackageVersion Include="ReportGenerator" Version="5.5.10" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.16.13" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />

--- a/sample/Directory.Packages.props
+++ b/sample/Directory.Packages.props
@@ -51,7 +51,7 @@
     <PackageVersion Include="Vogen" Version="8.0.5" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.2.3" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.5" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />

--- a/sample/Directory.Packages.props
+++ b/sample/Directory.Packages.props
@@ -44,6 +44,7 @@
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="SQLite" Version="3.13.0" />
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.53.3" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
     <PackageVersion Include="Testcontainers" Version="4.11.0" />

--- a/sample/src/NimblePros.SampleToDo.Infrastructure/NimblePros.SampleToDo.Infrastructure.csproj
+++ b/sample/src/NimblePros.SampleToDo.Infrastructure/NimblePros.SampleToDo.Infrastructure.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="NimblePros.Metronome" />
     <PackageReference Include="SQLite" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" />
     <PackageReference Include="Vogen" />
   </ItemGroup>
   

--- a/src/Clean.Architecture.Core/ContributorAggregate/Handlers/ContributorDeletedHandler.cs
+++ b/src/Clean.Architecture.Core/ContributorAggregate/Handlers/ContributorDeletedHandler.cs
@@ -8,7 +8,7 @@ public class ContributorDeletedHandler(ILogger<ContributorDeletedHandler> logger
 {
   public async ValueTask Handle(ContributorDeletedEvent domainEvent, CancellationToken cancellationToken)
   {
-    logger.LogInformation("Handling Contributed Deleted event for {contributorId}", domainEvent.ContributorId);
+    logger.LogInformation("Handling Contributed Deleted event for {ContributorId}", domainEvent.ContributorId);
 
     await emailSender.SendEmailAsync("to@test.com",
                                      "from@test.com",

--- a/src/Clean.Architecture.Core/ContributorAggregate/Handlers/ContributorNameUpdatedEmailNotificationHandler.cs
+++ b/src/Clean.Architecture.Core/ContributorAggregate/Handlers/ContributorNameUpdatedEmailNotificationHandler.cs
@@ -9,7 +9,7 @@ public class ContributorNameUpdatedEmailNotificationHandler(
 {
   public async ValueTask Handle(ContributorNameUpdatedEvent domainEvent, CancellationToken cancellationToken)
   {
-    logger.LogInformation("Handling Contributor Name Updated event for {contributorId}", domainEvent.Contributor.Id);
+    logger.LogInformation("Handling Contributor Name Updated event for {ContributorId}", domainEvent.Contributor.Id);
 
     await emailSender.SendEmailAsync("to@test.com",
                                      "from@test.com",

--- a/src/Clean.Architecture.Core/Interfaces/IEmailSender.cs
+++ b/src/Clean.Architecture.Core/Interfaces/IEmailSender.cs
@@ -2,5 +2,5 @@
 
 public interface IEmailSender
 {
-  Task SendEmailAsync(string to, string from, string subject, string body);
+  Task SendEmailAsync(string recipientEmail, string senderEmail, string subject, string body);
 }

--- a/src/Clean.Architecture.Core/Services/DeleteContributorService.cs
+++ b/src/Clean.Architecture.Core/Services/DeleteContributorService.cs
@@ -5,23 +5,41 @@ using Clean.Architecture.Core.Interfaces;
 namespace Clean.Architecture.Core.Services;
 
 /// <summary>
-/// This is here mainly so there's an example of a domain service
+/// This service is here mainly so there's an example of a domain service
 /// and also to demonstrate how to fire domain events from a service.
 /// </summary>
-/// <param name="_repository"></param>
-/// <param name="_mediator"></param>
-/// <param name="_logger"></param>
-public class DeleteContributorService(IRepository<Contributor> _repository,
-  IMediator _mediator,
-  ILogger<DeleteContributorService> _logger) : IDeleteContributorService
+/// <remarks>
+/// The logging call intentionally uses a precompiled <see cref="LoggerMessage" /> delegate.
+/// This avoids analyzer warning CA1848 and demonstrates the recommended high-performance
+/// logging pattern without using <c>LoggerExtensions.LogInformation</c> directly.
+/// </remarks>
+/// <param name="repository">The repository used to load and delete contributors.</param>
+/// <param name="mediator">The mediator used to publish domain events.</param>
+/// <param name="logger">The logger used by the service.</param>
+public class DeleteContributorService(
+  IRepository<Contributor> repository,
+  IMediator mediator,
+  ILogger<DeleteContributorService> logger) : IDeleteContributorService
 {
+  private static readonly Action<ILogger, ContributorId, Exception?> LogDeletingContributor =
+    LoggerMessage.Define<ContributorId>(
+      LogLevel.Information,
+      new EventId(1, nameof(DeleteContributor)),
+      "Deleting Contributor {ContributorId}");
+
+  private readonly IRepository<Contributor> _repository = repository;
+  private readonly IMediator _mediator = mediator;
+  private readonly ILogger<DeleteContributorService> _logger = logger;
+
   public async ValueTask<Result> DeleteContributor(ContributorId contributorId)
   {
-    _logger.LogInformation("Deleting Contributor {contributorId}", contributorId);
+    LogDeletingContributor(_logger, contributorId, null);
+
     Contributor? aggregateToDelete = await _repository.GetByIdAsync(contributorId);
     if (aggregateToDelete == null) return Result.NotFound();
 
     await _repository.DeleteAsync(aggregateToDelete);
+
     var domainEvent = new ContributorDeletedEvent(contributorId);
     await _mediator.Publish(domainEvent);
 

--- a/src/Clean.Architecture.Infrastructure/Data/Config/DataSchemaConstants.cs
+++ b/src/Clean.Architecture.Infrastructure/Data/Config/DataSchemaConstants.cs
@@ -2,5 +2,5 @@
 
 public static class DataSchemaConstants
 {
-  public const int DEFAULT_NAME_LENGTH = 100;
+  public const int DefaultNameLength = 100;
 }

--- a/src/Clean.Architecture.Infrastructure/Data/Config/VogenEfCoreConverters.cs
+++ b/src/Clean.Architecture.Infrastructure/Data/Config/VogenEfCoreConverters.cs
@@ -5,4 +5,4 @@ namespace Clean.Architecture.Infrastructure.Data.Config;
 
 [EfCoreConverter<ContributorId>]
 [EfCoreConverter<ContributorName>]
-internal partial class VogenEfCoreConverters;
+internal sealed partial class VogenEfCoreConverters;

--- a/src/Clean.Architecture.Infrastructure/Data/EventDispatcherInterceptor.cs
+++ b/src/Clean.Architecture.Infrastructure/Data/EventDispatcherInterceptor.cs
@@ -20,7 +20,7 @@ public class EventDispatchInterceptor(IDomainEventDispatcher domainEventDispatch
     // Retrieve all tracked entities that have domain events
     var entitiesWithEvents = appDbContext.ChangeTracker.Entries<HasDomainEventsBase>()
       .Select(e => e.Entity)
-      .Where(e => e.DomainEvents.Any())
+      .Where(e => e.DomainEvents.Count != 0)
       .ToArray();
 
     // Dispatch and clear domain events

--- a/src/Clean.Architecture.Infrastructure/Data/SeedData.cs
+++ b/src/Clean.Architecture.Infrastructure/Data/SeedData.cs
@@ -4,7 +4,7 @@ namespace Clean.Architecture.Infrastructure.Data;
 
 public static class SeedData
 {
-  public const int NUMBER_OF_CONTRIBUTORS = 27; // including the 2 below
+  public const int NumberOfContributors = 27; // including the 2 below
   public static readonly ContributorName Contributor1Name = ContributorName.From("Ardalis");
   public static readonly ContributorName Contributor2Name = ContributorName.From("Ilyana");
 
@@ -22,7 +22,7 @@ public static class SeedData
     await dbContext.Database.ExecuteSqlInterpolatedAsync($"INSERT INTO [Contributors] ([Name], [Status]) VALUES ({Contributor2Name.Value}, {ContributorStatus.NotSet.Value})");
 
     // Add a bunch more contributors to support demonstrating paging.
-    for (int i = 1; i <= NUMBER_OF_CONTRIBUTORS - 2; i++)
+    for (int i = 1; i <= NumberOfContributors - 2; i++)
     {
       await dbContext.Database.ExecuteSqlInterpolatedAsync($"INSERT INTO [Contributors] ([Name], [Status]) VALUES ({$"Contributor {i}"}, {ContributorStatus.NotSet.Value})");
     }

--- a/src/Clean.Architecture.Infrastructure/Email/FakeEmailSender.cs
+++ b/src/Clean.Architecture.Infrastructure/Email/FakeEmailSender.cs
@@ -5,9 +5,9 @@ namespace Clean.Architecture.Infrastructure.Email;
 public class FakeEmailSender(ILogger<FakeEmailSender> logger) : IEmailSender
 {
   private readonly ILogger<FakeEmailSender> _logger = logger;
-  public Task SendEmailAsync(string to, string from, string subject, string body)
+  public Task SendEmailAsync(string recipientEmail, string senderEmail, string subject, string body)
   {
-    _logger.LogInformation("Not actually sending an email to {to} from {from} with subject {subject}", to, from, subject);
+    _logger.LogInformation("Not actually sending an email to {To} from {From} with subject {Subject}", recipientEmail, senderEmail, subject);
     return Task.CompletedTask;
   }
 }

--- a/src/Clean.Architecture.Infrastructure/Email/MimeKitEmailSender.cs
+++ b/src/Clean.Architecture.Infrastructure/Email/MimeKitEmailSender.cs
@@ -8,22 +8,22 @@ public class MimeKitEmailSender(ILogger<MimeKitEmailSender> logger,
   private readonly ILogger<MimeKitEmailSender> _logger = logger;
   private readonly MailserverConfiguration _mailserverConfiguration = mailserverOptions.Value!;
 
-  public async Task SendEmailAsync(string to, string from, string subject, string body)
+  public async Task SendEmailAsync(string recipientEmail, string senderEmail, string subject, string body)
   {
-    _logger.LogWarning("Sending email to {to} from {from} with subject {subject} using {type}.", to, from, subject, this.ToString());
+    _logger.LogWarning("Sending email to {To} from {From} with subject {Subject} using {Type}.", recipientEmail, senderEmail, subject, this.ToString());
 
-    using var client = new MailKit.Net.Smtp.SmtpClient(); 
-    await client.ConnectAsync(_mailserverConfiguration.Hostname, 
+    using var client = new MailKit.Net.Smtp.SmtpClient();
+    await client.ConnectAsync(_mailserverConfiguration.Hostname,
       _mailserverConfiguration.Port, false);
     var message = new MimeMessage();
-    message.From.Add(new MailboxAddress(from, from));
-    message.To.Add(new MailboxAddress(to, to));
+    message.From.Add(new MailboxAddress(senderEmail, senderEmail));
+    message.To.Add(new MailboxAddress(recipientEmail, recipientEmail));
     message.Subject = subject;
     message.Body = new TextPart("plain") { Text = body };
 
     await client.SendAsync(message);
 
-    await client.DisconnectAsync(true, 
+    await client.DisconnectAsync(true,
       new CancellationToken(canceled: true));
   }
 }

--- a/src/Clean.Architecture.ServiceDefaults/Extensions.cs
+++ b/src/Clean.Architecture.ServiceDefaults/Extensions.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.ServiceDiscovery;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
@@ -34,12 +33,13 @@ public static class Extensions
       // Turn on service discovery by default
       http.AddServiceDiscovery();
     });
-
+#pragma warning disable S125 // This template intentionally contains commented sample configuration.
     // Uncomment the following to restrict the allowed schemes for service discovery.
     // builder.Services.Configure<ServiceDiscoveryOptions>(options =>
     // {
     //     options.AllowedSchemes = ["https"];
     // });
+#pragma warning restore S125
 
     return builder;
   }
@@ -65,8 +65,8 @@ public static class Extensions
                   .AddAspNetCoreInstrumentation(tracing =>
                       // Exclude health check requests from tracing
                       tracing.Filter = context =>
-                          !context.Request.Path.StartsWithSegments(HealthEndpointPath)
-                          && !context.Request.Path.StartsWithSegments(AlivenessEndpointPath)
+                          !context.Request.Path.StartsWithSegments(HealthEndpointPath, StringComparison.OrdinalIgnoreCase)
+                          && !context.Request.Path.StartsWithSegments(AlivenessEndpointPath, StringComparison.OrdinalIgnoreCase)
                   )
                   // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
                   //.AddGrpcClientInstrumentation()
@@ -86,13 +86,14 @@ public static class Extensions
     {
       builder.Services.AddOpenTelemetry().UseOtlpExporter();
     }
-
+#pragma warning disable S125   //this is there on purpose to show how to conditionally add exporters based on configuration, and to avoid confusion about the presence of multiple exporters in this template.
     // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
     //if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
     //{
     //    builder.Services.AddOpenTelemetry()
     //       .UseAzureMonitor();
     //}
+#pragma warning  restore
 
     return builder;
   }

--- a/src/Clean.Architecture.UseCases/Constants.cs
+++ b/src/Clean.Architecture.UseCases/Constants.cs
@@ -1,7 +1,7 @@
 ﻿namespace Clean.Architecture.UseCases;
 
-public class Constants
+public static class Constants
 {
-  public const int DEFAULT_PAGE_SIZE = 10;
-  public const int MAX_PAGE_SIZE = 100;
+  public const int DefaultPageSize = 10;
+  public const int MaxPageSize = 100;
 }

--- a/src/Clean.Architecture.UseCases/Contributors/Get/GetContributorHandler.cs
+++ b/src/Clean.Architecture.UseCases/Contributors/Get/GetContributorHandler.cs
@@ -1,18 +1,19 @@
 ﻿using Clean.Architecture.Core.ContributorAggregate;
 using Clean.Architecture.Core.ContributorAggregate.Specifications;
+using Clean.Architecture.UseCases.Contributors.GetContributor;
 
 namespace Clean.Architecture.UseCases.Contributors.Get;
 
 /// <summary>
 /// Queries don't necessarily need to use repository methods, but they can if it's convenient
 /// </summary>
-public class GetContributorHandler(IReadRepository<Contributor> _repository)
+public class GetContributorHandler(IReadRepository<Contributor> repository)
   : IQueryHandler<GetContributorQuery, Result<ContributorDto>>
 {
   public async ValueTask<Result<ContributorDto>> Handle(GetContributorQuery request, CancellationToken cancellationToken)
   {
     var spec = new ContributorByIdSpec(request.ContributorId);
-    var entity = await _repository.FirstOrDefaultAsync(spec, cancellationToken);
+    var entity = await repository.FirstOrDefaultAsync(spec, cancellationToken);
     if (entity == null) return Result.NotFound();
 
     return new ContributorDto(entity.Id, entity.Name, entity.PhoneNumber ?? PhoneNumber.Unknown);

--- a/src/Clean.Architecture.UseCases/Contributors/GetContributor/GetContributorQuery.cs
+++ b/src/Clean.Architecture.UseCases/Contributors/GetContributor/GetContributorQuery.cs
@@ -1,5 +1,5 @@
 ﻿using Clean.Architecture.Core.ContributorAggregate;
 
-namespace Clean.Architecture.UseCases.Contributors.Get;
+namespace Clean.Architecture.UseCases.Contributors.GetContributor;
 
 public record GetContributorQuery(ContributorId ContributorId) : IQuery<Result<ContributorDto>>;

--- a/src/Clean.Architecture.UseCases/Contributors/List/ListContributorsHandler.cs
+++ b/src/Clean.Architecture.UseCases/Contributors/List/ListContributorsHandler.cs
@@ -13,7 +13,7 @@ public class ListContributorsHandler : IQueryHandler<ListContributorsQuery, Resu
                                                                      CancellationToken cancellationToken)
   {
 
-    var result = await _query.ListAsync(request.Page ?? 1, request.PerPage ?? Constants.DEFAULT_PAGE_SIZE);
+    var result = await _query.ListAsync(request.Page ?? 1, request.PerPage ?? Constants.DefaultPageSize);
 
     return Result.Success(result);
   }

--- a/src/Clean.Architecture.UseCases/Contributors/List/ListContributorsQuery.cs
+++ b/src/Clean.Architecture.UseCases/Contributors/List/ListContributorsQuery.cs
@@ -1,4 +1,4 @@
 ﻿namespace Clean.Architecture.UseCases.Contributors.List;
 
-public record ListContributorsQuery(int? Page = 1, int? PerPage = Constants.DEFAULT_PAGE_SIZE)
+public record ListContributorsQuery(int? Page = 1, int? PerPage = Constants.DefaultPageSize)
   : IQuery<Result<PagedResult<ContributorDto>>>;

--- a/src/Clean.Architecture.UseCases/Contributors/Update/UpdateContributorHandler.cs
+++ b/src/Clean.Architecture.UseCases/Contributors/Update/UpdateContributorHandler.cs
@@ -5,10 +5,10 @@ namespace Clean.Architecture.UseCases.Contributors.Update;
 public class UpdateContributorHandler(IRepository<Contributor> _repository)
   : ICommandHandler<UpdateContributorCommand, Result<ContributorDto>>
 {
-  public async ValueTask<Result<ContributorDto>> Handle(UpdateContributorCommand command, 
-    CancellationToken ct)
+  public async ValueTask<Result<ContributorDto>> Handle(UpdateContributorCommand command,
+    CancellationToken cancellationToken)
   {
-    var existingContributor = await _repository.GetByIdAsync(command.ContributorId, ct);
+    var existingContributor = await _repository.GetByIdAsync(command.ContributorId, cancellationToken);
     if (existingContributor == null)
     {
       return Result.NotFound();
@@ -16,7 +16,7 @@ public class UpdateContributorHandler(IRepository<Contributor> _repository)
 
     existingContributor.UpdateName(command.NewName);
 
-    await _repository.UpdateAsync(existingContributor, ct);
+    await _repository.UpdateAsync(existingContributor, cancellationToken);
 
     return new ContributorDto(existingContributor.Id,
       existingContributor.Name, existingContributor.PhoneNumber ?? PhoneNumber.Unknown);

--- a/src/Clean.Architecture.Web/Configurations/LoggerConfigs.cs
+++ b/src/Clean.Architecture.Web/Configurations/LoggerConfigs.cs
@@ -1,4 +1,5 @@
-﻿using Serilog;
+﻿using System.Globalization;
+using Serilog;
 
 namespace Clean.Architecture.Web.Configurations;
 
@@ -12,7 +13,7 @@ public static class LoggerConfigs
       .ReadFrom.Configuration(builder.Configuration)
       .Enrich.FromLogContext()
       .Enrich.WithProperty("Application", builder.Environment.ApplicationName)
-      .WriteTo.Console()
+      .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
       .CreateLogger());
 
     return builder;

--- a/src/Clean.Architecture.Web/Configurations/MiddlewareConfig.cs
+++ b/src/Clean.Architecture.Web/Configurations/MiddlewareConfig.cs
@@ -14,7 +14,7 @@ public static class MiddlewareConfig
       app.UseShowAllServicesMiddleware(); // see https://github.com/ardalis/AspNetCoreStartupServices
     }
     else
-    {   
+    {
       app.UseDefaultExceptionHandler(); // from FastEndpoints
       app.UseHsts();
     }
@@ -32,7 +32,7 @@ public static class MiddlewareConfig
         settings.Path = "/swagger";
         settings.DocumentPath = "/openapi/{documentName}.json";
       });
-  
+
       app.MapScalarApiReference(options =>
       {
         options.WithTitle("Clean Architecture API");
@@ -43,9 +43,9 @@ public static class MiddlewareConfig
     app.UseHttpsRedirection(); // Note this will drop Authorization headers
 
     // Run migrations and seed in Development or when explicitly requested via environment variable
-    var shouldMigrate = app.Environment.IsDevelopment() || 
+    var shouldMigrate = app.Environment.IsDevelopment() ||
                         app.Configuration.GetValue<bool>("Database:ApplyMigrationsOnStartup");
-    
+
     if (shouldMigrate)
     {
       await MigrateDatabaseAsync(app);
@@ -65,7 +65,7 @@ public static class MiddlewareConfig
     {
       logger.LogInformation("Applying database migrations...");
       var context = services.GetRequiredService<AppDbContext>();
-      
+
       // For SQLite, use EnsureCreated instead of migrations (common for dev/local scenarios)
       // For SQL Server, use migrations (production scenario)
       if (context.Database.IsSqlite())
@@ -81,7 +81,7 @@ public static class MiddlewareConfig
     }
     catch (Exception ex)
     {
-      logger.LogError(ex, "An error occurred migrating the DB. {exceptionMessage}", ex.Message);
+      logger.LogError(ex, "An error occurred migrating the DB. {ExceptionMessage}", ex.Message);
       throw; // Re-throw to make startup fail if migrations fail
     }
   }
@@ -101,7 +101,7 @@ public static class MiddlewareConfig
     }
     catch (Exception ex)
     {
-      logger.LogError(ex, "An error occurred seeding the DB. {exceptionMessage}", ex.Message);
+      logger.LogError(ex, "An error occurred seeding the DB. {ExceptionMessage}", ex.Message);
       // Don't re-throw for seeding errors - it's not critical
     }
   }

--- a/src/Clean.Architecture.Web/Contributors/Create.cs
+++ b/src/Clean.Architecture.Web/Contributors/Create.cs
@@ -49,9 +49,9 @@ public class Create(IMediator mediator)
   }
 
   public override async Task<Results<Created<CreateContributorResponse>, ValidationProblem, ProblemHttpResult>>
-    ExecuteAsync(CreateContributorRequest request, CancellationToken cancellationToken)
+    ExecuteAsync(CreateContributorRequest request, CancellationToken ct)
   {
-    var result = await _mediator.Send(new CreateContributorCommand(ContributorName.From(request.Name!), request.PhoneNumber));
+    var result = await _mediator.Send(new CreateContributorCommand(ContributorName.From(request.Name!), request.PhoneNumber), ct);
 
     return result.ToCreatedResult(
       id => $"/Contributors/{id}",
@@ -65,7 +65,7 @@ public class CreateContributorRequest
 
   [Required]
   public string Name { get; set; } = String.Empty;
-  public string? PhoneNumber { get; set; } = null;
+  public string? PhoneNumber { get; set; }
 }
 
 public class CreateContributorValidator : Validator<CreateContributorRequest>

--- a/src/Clean.Architecture.Web/Contributors/Delete.DeleteContributorRequest.cs
+++ b/src/Clean.Architecture.Web/Contributors/Delete.DeleteContributorRequest.cs
@@ -1,9 +1,11 @@
-﻿namespace Clean.Architecture.Web.Contributors;
+﻿using System.Globalization;
+
+namespace Clean.Architecture.Web.Contributors;
 
 public record DeleteContributorRequest
 {
   public const string Route = "/Contributors/{ContributorId:int}";
-  public static string BuildRoute(int contributorId) => Route.Replace("{ContributorId:int}", contributorId.ToString());
+  public static string BuildRoute(int contributorId) => Route.Replace("{ContributorId:int}", contributorId.ToString(CultureInfo.InvariantCulture), StringComparison.InvariantCulture);
 
   public int ContributorId { get; set; }
 }

--- a/src/Clean.Architecture.Web/Contributors/GetById.GetContributorByIdRequest.cs
+++ b/src/Clean.Architecture.Web/Contributors/GetById.GetContributorByIdRequest.cs
@@ -1,9 +1,11 @@
-﻿namespace Clean.Architecture.Web.Contributors;
+﻿using System.Globalization;
+
+namespace Clean.Architecture.Web.Contributors;
 
 public class GetContributorByIdRequest
 {
   public const string Route = "/Contributors/{ContributorId:int}";
-  public static string BuildRoute(int contributorId) => Route.Replace("{ContributorId:int}", contributorId.ToString());
+  public static string BuildRoute(int contributorId) => Route.Replace("{ContributorId:int}", contributorId.ToString(CultureInfo.InvariantCulture), StringComparison.InvariantCulture);
 
   public int ContributorId { get; set; }
 }

--- a/src/Clean.Architecture.Web/Contributors/GetById.cs
+++ b/src/Clean.Architecture.Web/Contributors/GetById.cs
@@ -1,6 +1,6 @@
 ﻿using Clean.Architecture.Core.ContributorAggregate;
 using Clean.Architecture.UseCases.Contributors;
-using Clean.Architecture.UseCases.Contributors.Get;
+using Clean.Architecture.UseCases.Contributors.GetContributor;
 using Clean.Architecture.Web.Extensions;
 using Microsoft.AspNetCore.Http.HttpResults;
 

--- a/src/Clean.Architecture.Web/Contributors/List.cs
+++ b/src/Clean.Architecture.Web/Contributors/List.cs
@@ -29,7 +29,7 @@ public class List(IMediator mediator) : Endpoint<ListContributorsRequest, Contri
 
       // Document pagination parameters
       s.Params["page"] = "1-based page index (default 1)";
-      s.Params["per_page"] = $"Page size 1–{UseCases.Constants.MAX_PAGE_SIZE} (default {UseCases.Constants.DEFAULT_PAGE_SIZE})";
+      s.Params["per_page"] = $"Page size 1–{UseCases.Constants.MaxPageSize} (default {UseCases.Constants.DefaultPageSize})";
 
       // Document possible responses
       s.Responses[200] = "Paginated list of contributors returned successfully";
@@ -46,12 +46,12 @@ public class List(IMediator mediator) : Endpoint<ListContributorsRequest, Contri
       .ProducesProblem(400));
   }
 
-  public override async Task HandleAsync(ListContributorsRequest request, CancellationToken cancellationToken)
+  public override async Task HandleAsync(ListContributorsRequest request, CancellationToken ct)
   {
-    var result = await _mediator.Send(new ListContributorsQuery(request.Page, request.PerPage));
+    var result = await _mediator.Send(new ListContributorsQuery(request.Page, request.PerPage), ct);
     if (!result.IsSuccess)
     {
-      await Send.ErrorsAsync(statusCode: 400, cancellationToken);
+      await Send.ErrorsAsync(statusCode: 400, ct);
       return;
     }
 
@@ -59,7 +59,7 @@ public class List(IMediator mediator) : Endpoint<ListContributorsRequest, Contri
     AddLinkHeader(pagedResult.Page, pagedResult.PerPage, pagedResult.TotalPages);
 
     var response = Map.FromEntity(pagedResult);
-    await Send.OkAsync(response, cancellationToken);
+    await Send.OkAsync(response, ct);
   }
 
   private void AddLinkHeader(int page, int perPage, int totalPages)
@@ -92,7 +92,7 @@ public sealed class ListContributorsRequest
 
   // Bind to ?per_page=
   [BindFrom("per_page")]
-  public int PerPage { get; init; } = UseCases.Constants.DEFAULT_PAGE_SIZE;
+  public int PerPage { get; init; } = UseCases.Constants.DefaultPageSize;
 }
 
 public record ContributorListResponse : UseCases.PagedResult<ContributorRecord>
@@ -113,8 +113,8 @@ public sealed class ListContributorsValidator : Validator<ListContributorsReques
       .WithMessage("page must be >= 1");
 
     RuleFor(x => x.PerPage)
-      .InclusiveBetween(1, UseCases.Constants.MAX_PAGE_SIZE)
-      .WithMessage($"per_page must be between 1 and {UseCases.Constants.MAX_PAGE_SIZE}");
+      .InclusiveBetween(1, UseCases.Constants.MaxPageSize)
+      .WithMessage($"per_page must be between 1 and {UseCases.Constants.MaxPageSize}");
   }
 }
 

--- a/src/Clean.Architecture.Web/Contributors/Update.UpdateContributorRequest.cs
+++ b/src/Clean.Architecture.Web/Contributors/Update.UpdateContributorRequest.cs
@@ -1,11 +1,12 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 
 namespace Clean.Architecture.Web.Contributors;
 
 public class UpdateContributorRequest
 {
   public const string Route = "/Contributors/{ContributorId:int}";
-  public static string BuildRoute(int contributorId) => Route.Replace("{ContributorId:int}", contributorId.ToString());
+  public static string BuildRoute(int contributorId) => Route.Replace("{ContributorId:int}", contributorId.ToString(CultureInfo.InvariantCulture), StringComparison.InvariantCulture);
 
   public int ContributorId { get; set; }
 

--- a/src/Clean.Architecture.Web/Contributors/Update.UpdateContributorValidator.cs
+++ b/src/Clean.Architecture.Web/Contributors/Update.UpdateContributorValidator.cs
@@ -1,5 +1,4 @@
 ﻿using Clean.Architecture.Infrastructure.Data.Config;
-using FastEndpoints;
 using FluentValidation;
 
 namespace Clean.Architecture.Web.Contributors;
@@ -15,7 +14,7 @@ public class UpdateContributorValidator : Validator<UpdateContributorRequest>
       .NotEmpty()
       .WithMessage("Name is required.")
       .MinimumLength(2)
-      .MaximumLength(DataSchemaConstants.DEFAULT_NAME_LENGTH);
+      .MaximumLength(DataSchemaConstants.DefaultNameLength);
     RuleFor(x => x.ContributorId)
       .Must((args, contributorId) => args.Id == contributorId)
       .WithMessage("Route and body Ids must match; cannot update Id of an existing resource.");

--- a/src/Clean.Architecture.Web/Contributors/Update.cs
+++ b/src/Clean.Architecture.Web/Contributors/Update.cs
@@ -1,6 +1,5 @@
 ﻿using Clean.Architecture.Core.ContributorAggregate;
 using Clean.Architecture.UseCases.Contributors;
-using Clean.Architecture.UseCases.Contributors.Get;
 using Clean.Architecture.UseCases.Contributors.Update;
 using Clean.Architecture.Web.Extensions;
 using Microsoft.AspNetCore.Http.HttpResults;

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -1,7 +1,7 @@
 ###############################
 # Core EditorConfig Options   #
 ###############################
-root = true
+root = false
 # All files
 [*]
 indent_style = space
@@ -146,12 +146,6 @@ csharp_style_expression_bodied_local_functions = false:silent
 
 dotnet_diagnostic.CA1707.severity = none
 
-dotnet_diagnostic.CA1014.severity = none
-// CA1848: Use 'LoggerMessage.Define' instead of 'LoggerMessage.Define<T>' 
-// DO not force Logger Massages Delegates all everywhere 
-dotnet_diagnostic.CA1848.severity= none
-# Avoid forcing LoggerMessage-style logging everywhere in this template/sample repository.
-dotnet_diagnostic.CA1873.severity = none
 
 ###############################
 # VB Coding Conventions       #

--- a/tests/.runsettings
+++ b/tests/.runsettings
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <!-- Enable parallel test execution at the assembly level -->
+    <MaxCpuCount>0</MaxCpuCount>
+    <!-- 0 means use all available processors -->
+    <DisableParallelization>false</DisableParallelization>
+  </RunConfiguration>
+  
+  <xUnit>
+    <!-- Configure xUnit-specific settings -->
+    <ParallelizeAssembly>true</ParallelizeAssembly>
+    <ParallelizeTestCollections>true</ParallelizeTestCollections>
+    <MaxParallelThreads>0</MaxParallelThreads>
+    <!-- 0 means use default algorithm (processors * 2) -->
+  </xUnit>
+</RunSettings>

--- a/tests/Clean.Architecture.AspireTests/Clean.Architecture.AspireTests.csproj
+++ b/tests/Clean.Architecture.AspireTests/Clean.Architecture.AspireTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/Clean.Architecture.FunctionalTests/ApiEndpoints/ContributorList.cs
+++ b/tests/Clean.Architecture.FunctionalTests/ApiEndpoints/ContributorList.cs
@@ -13,7 +13,7 @@ public class ContributorList(CustomWebApplicationFactory<Program> factory) : ICl
   {
     var result = await _client.GetAndDeserializeAsync<ContributorListResponse>("/Contributors");
 
-    Assert.Equal(SeedData.NUMBER_OF_CONTRIBUTORS, result.TotalCount);
+    Assert.Equal(SeedData.NumberOfContributors, result.TotalCount);
     Assert.Contains(result.Items, i => i.Name == SeedData.Contributor1Name.Value);
     Assert.Contains(result.Items, i => i.Name == SeedData.Contributor2Name.Value);
   }

--- a/tests/Clean.Architecture.FunctionalTests/CustomWebApplicationFactory.cs
+++ b/tests/Clean.Architecture.FunctionalTests/CustomWebApplicationFactory.cs
@@ -25,7 +25,7 @@ public class CustomWebApplicationFactory<TProgram> : WebApplicationFactory<TProg
     }
   }
 
-  public new async ValueTask DisposeAsync()
+  public override async ValueTask DisposeAsync()
   {
     // Clean up environment variable
     Environment.SetEnvironmentVariable("USE_SQL_SERVER", null);
@@ -33,6 +33,9 @@ public class CustomWebApplicationFactory<TProgram> : WebApplicationFactory<TProg
     {
       await _dbContainer.DisposeAsync();
     }
+
+    await base.DisposeAsync();
+    GC.SuppressFinalize(this);
   }
 
   /// <summary>
@@ -71,7 +74,7 @@ public class CustomWebApplicationFactory<TProgram> : WebApplicationFactory<TProg
       }
       catch (Exception ex)
       {
-        logger.LogError(ex, "An error occurred seeding the database with test messages. Error: {exceptionMessage}", ex.Message);
+        logger.LogError(ex, "An error occurred seeding the database with test messages. Error: {ExceptionMessage}", ex.Message);
         throw;
       }
     }

--- a/tests/Clean.Architecture.IntegrationTests/Data/BaseEfRepoTestFixture.cs
+++ b/tests/Clean.Architecture.IntegrationTests/Data/BaseEfRepoTestFixture.cs
@@ -3,9 +3,11 @@ using Clean.Architecture.Infrastructure.Data;
 
 namespace Clean.Architecture.IntegrationTests.Data;
 
-public abstract class BaseEfRepoTestFixture
+public abstract class BaseEfRepoTestFixture : IDisposable, IAsyncDisposable
 {
-  protected AppDbContext _dbContext;
+  private readonly AppDbContext _dbContext;
+
+  protected AppDbContext DbContext => _dbContext;
 
   protected BaseEfRepoTestFixture()
   {
@@ -39,5 +41,17 @@ public abstract class BaseEfRepoTestFixture
   protected EfRepository<Contributor> GetRepository()
   {
     return new EfRepository<Contributor>(_dbContext);
+  }
+
+  public void Dispose()
+  {
+    GC.SuppressFinalize(this);
+    _dbContext.Dispose();
+  }
+
+  public async ValueTask DisposeAsync()
+  {
+    GC.SuppressFinalize(this);
+    await _dbContext.DisposeAsync();
   }
 }

--- a/tests/Clean.Architecture.IntegrationTests/Data/EfRepositoryUpdate.cs
+++ b/tests/Clean.Architecture.IntegrationTests/Data/EfRepositoryUpdate.cs
@@ -16,7 +16,7 @@ public class EfRepositoryUpdate : BaseEfRepoTestFixture
     await repository.AddAsync(Contributor, cancellationToken);
 
     // detach the item so we get a different instance
-    _dbContext.Entry(Contributor).State = EntityState.Detached;
+    DbContext.Entry(Contributor).State = EntityState.Detached;
 
     // fetch the item and update its title
     var newContributor = (await repository.ListAsync(cancellationToken))

--- a/tests/Clean.Architecture.UnitTests/NoOpMediator.cs
+++ b/tests/Clean.Architecture.UnitTests/NoOpMediator.cs
@@ -2,9 +2,9 @@
 
 public class NoOpMediator : IMediator
 {
-  public async Task<IAsyncEnumerable<TResponse>> CreateStream<TResponse>(IStreamQuery<TResponse> query, CancellationToken cancellationToken = default)
+  public static async Task<IAsyncEnumerable<TResponse>> CreateStream<TResponse>(IStreamQuery<TResponse> query, CancellationToken cancellationToken = default)
   {
-    await Task.Delay(1);
+    await Task.Delay(1, cancellationToken);
     return AsyncEnumerable.Empty<TResponse>();
   }
 


### PR DESCRIPTION
## Summary

* Make the functional test database provider explicitly selectable.
* Keep SQL Server through Testcontainers as the preferred provider.
* Fall back to SQLite only when Docker is unavailable.
* Avoid failing the complete test run when Docker-specific coverage cannot run.
* Use an isolated temporary SQLite database for each test factory.
* Clean up the temporary SQLite database files after the test run.
* Expose the active database provider for diagnostics and assertions.
* Add tests that verify the SQLite provider and a functional endpoint using SQLite.

## Behavior

When Docker is available:

* SQL Server Testcontainers are used.
* All functional tests run with SQL Server.
* The Docker-specific test runs normally.

When Docker is unavailable:

* The functional test factory falls back to SQLite.
* The Docker-specific test is skipped.
* The remaining functional tests continue to pass.

Only `DockerUnavailableException` triggers the fallback or skipped test. Other container or SQL Server startup errors remain visible as test failures.

## Verification

With Docker running:

```text
Total tests: 6
Passed: 6
Failed: 0
Skipped: 0
```

With Docker stopped:

```text
Total tests: 6
Passed: 5
Failed: 0
Skipped: 1
```

Closes #1028
