### PR TITLE
Make SQLite fallback reliable when Docker is unavailable

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Keep NU1903 visible while the dependency fix is handled separately in PR #1067. -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1903</WarningsNotAsErrors>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/Clean.Architecture.FunctionalTests/CustomWebApplicationFactory.cs
+++ b/tests/Clean.Architecture.FunctionalTests/CustomWebApplicationFactory.cs
@@ -1,79 +1,132 @@
 ﻿using Clean.Architecture.Infrastructure.Data;
+using DotNet.Testcontainers.Builders;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Testcontainers.MsSql;
 
 namespace Clean.Architecture.FunctionalTests;
 
-public class CustomWebApplicationFactory<TProgram> : WebApplicationFactory<TProgram>, IAsyncLifetime where TProgram : class
+public class CustomWebApplicationFactory<TProgram> :
+  WebApplicationFactory<TProgram>,
+  IAsyncLifetime
+  where TProgram : class
 {
+  private TestDatabaseProvider _requestedDatabaseProvider =
+    TestDatabaseProvider.Auto;
+
+  private readonly string _sqliteDatabasePath = Path.Combine(
+    Path.GetTempPath(),
+    $"clean-architecture-functional-tests-{Guid.NewGuid():N}.db");
+
   private MsSqlContainer? _dbContainer;
+
+  public CustomWebApplicationFactory()
+  {
+    ActiveDatabaseProvider = TestDatabaseProvider.Auto;
+  }
+
+  public TestDatabaseProvider ActiveDatabaseProvider { get; private set; }
+
+  internal static CustomWebApplicationFactory<TProgram> CreateWithProvider(
+    TestDatabaseProvider databaseProvider)
+  {
+    return new CustomWebApplicationFactory<TProgram>
+    {
+      _requestedDatabaseProvider = databaseProvider,
+      ActiveDatabaseProvider = databaseProvider == TestDatabaseProvider.Sqlite
+        ? TestDatabaseProvider.Sqlite
+        : TestDatabaseProvider.Auto
+    };
+  }
 
   public async ValueTask InitializeAsync()
   {
+    if (_requestedDatabaseProvider == TestDatabaseProvider.Sqlite)
+    {
+      ActiveDatabaseProvider = TestDatabaseProvider.Sqlite;
+      return;
+    }
+
+    MsSqlContainer? container = null;
+
     try
     {
-      _dbContainer = new MsSqlBuilder("mcr.microsoft.com/mssql/server:2025-latest")
+      container = new MsSqlBuilder(
+          "mcr.microsoft.com/mssql/server:2025-latest")
         .WithPassword("Your_password123!")
         .Build();
-      await _dbContainer.StartAsync();
+
+      await container.StartAsync();
+      _dbContainer = container;
+      ActiveDatabaseProvider = TestDatabaseProvider.SqlServer;
     }
-    catch (ArgumentException)
+    catch (DockerUnavailableException) when (
+      _requestedDatabaseProvider == TestDatabaseProvider.Auto)
     {
-      // Docker is not available; fall back to SQLite (configured via appsettings.Testing.json)
-      _dbContainer = null;
+      await DisposeContainerAfterFailedStartAsync(container);
+      ActiveDatabaseProvider = TestDatabaseProvider.Sqlite;
+    }
+    catch
+    {
+      await DisposeContainerAfterFailedStartAsync(container);
+      throw;
     }
   }
 
-  public new async ValueTask DisposeAsync()
+  public override async ValueTask DisposeAsync()
   {
-    // Clean up environment variable
     Environment.SetEnvironmentVariable("USE_SQL_SERVER", null);
+
     if (_dbContainer != null)
     {
       await _dbContainer.DisposeAsync();
     }
+
+    await base.DisposeAsync();
+
+    if (File.Exists(_sqliteDatabasePath))
+    {
+      File.Delete(_sqliteDatabasePath);
+    }
+
+    GC.SuppressFinalize(this);
   }
 
   /// <summary>
   /// Overriding CreateHost to avoid creating a separate ServiceProvider per this thread:
   /// https://github.com/dotnet-architecture/eShopOnWeb/issues/465
   /// </summary>
-  /// <param name="builder"></param>
-  /// <returns></returns>
   protected override IHost CreateHost(IHostBuilder builder)
   {
-    builder.UseEnvironment("Testing"); // will not send real emails
+    builder.UseEnvironment("Testing");
+
     var host = builder.Build();
     host.Start();
 
-    // Get service provider.
-    var serviceProvider = host.Services;
+    using var scope = host.Services.CreateScope();
 
-    // Create a scope to obtain a reference to the database
-    // context (AppDbContext).
-    using (var scope = serviceProvider.CreateScope())
+    var scopedServices = scope.ServiceProvider;
+    var db = scopedServices.GetRequiredService<AppDbContext>();
+    var logger = scopedServices.GetRequiredService<
+      ILogger<CustomWebApplicationFactory<TProgram>>>();
+
+    try
     {
-      var scopedServices = scope.ServiceProvider;
-      var db = scopedServices.GetRequiredService<AppDbContext>();
+      logger.LogInformation(
+        "Functional tests are using the {DatabaseProvider} database provider.",
+        ActiveDatabaseProvider);
 
-      var logger = scopedServices
-          .GetRequiredService<ILogger<CustomWebApplicationFactory<TProgram>>>();
+      db.Database.EnsureCreated();
 
-      try
-      {
-        // Functional tests use EnsureCreated to avoid migration-script coupling.
-        db.Database.EnsureCreated();
-
-        // Seed the database with test data only if it has not been seeded yet.
-        // This is safe for container reuse across test runs and multiple fixture instances.
-        SeedData.InitializeAsync(db).GetAwaiter().GetResult();
-      }
-      catch (Exception ex)
-      {
-        logger.LogError(ex, "An error occurred seeding the database with test messages. Error: {exceptionMessage}", ex.Message);
-        throw;
-      }
+      SeedData.InitializeAsync(db).GetAwaiter().GetResult();
+    }
+    catch (Exception ex)
+    {
+      logger.LogError(
+        ex,
+        "An error occurred seeding the database with test messages. Error: {ExceptionMessage}",
+        ex.Message);
+      throw;
     }
 
     return host;
@@ -81,47 +134,86 @@ public class CustomWebApplicationFactory<TProgram> : WebApplicationFactory<TProg
 
   protected override void ConfigureWebHost(IWebHostBuilder builder)
   {
-    if (_dbContainer != null)
+    var useSqlServer = _dbContainer != null;
+
+    if (_requestedDatabaseProvider == TestDatabaseProvider.SqlServer &&
+        !useSqlServer)
     {
-      // Force SQL Server mode even on non-Windows platforms for functional tests
-      Environment.SetEnvironmentVariable("USE_SQL_SERVER", "true");
+      throw new InvalidOperationException(
+        "SQL Server was explicitly selected, but the test container has not " +
+        "been initialized. Use the factory as an xUnit fixture or call " +
+        "InitializeAsync before creating the client.");
     }
 
+    ActiveDatabaseProvider = useSqlServer
+      ? TestDatabaseProvider.SqlServer
+      : TestDatabaseProvider.Sqlite;
+
+    var connectionString = useSqlServer
+      ? _dbContainer!.GetConnectionString()
+      : $"Data Source={_sqliteDatabasePath}";
+
     builder
-        .ConfigureAppConfiguration((context, config) =>
-        {
-          if (_dbContainer != null)
+      .ConfigureAppConfiguration((_, config) =>
+      {
+        config.AddInMemoryCollection(
+          new Dictionary<string, string?>
           {
-            // Set the connection string to use the Testcontainer
-            config.AddInMemoryCollection(new Dictionary<string, string?>
-            {
-              ["ConnectionStrings:DefaultConnection"] = _dbContainer.GetConnectionString()
-            });
-          }
-        })
-        .ConfigureServices(services =>
+            ["ConnectionStrings:DefaultConnection"] =
+              useSqlServer ? connectionString : null,
+            ["ConnectionStrings:SqliteConnection"] =
+              useSqlServer ? null : connectionString
+          });
+      })
+      .ConfigureServices(services =>
+      {
+        var descriptors = services
+          .Where(
+            descriptor =>
+              descriptor.ServiceType == typeof(AppDbContext) ||
+              descriptor.ServiceType ==
+                typeof(DbContextOptions<AppDbContext>))
+          .ToList();
+
+        foreach (var descriptor in descriptors)
         {
-          if (_dbContainer != null)
+          services.Remove(descriptor);
+        }
+
+        services.AddDbContext<AppDbContext>((provider, options) =>
+        {
+          if (useSqlServer)
           {
-            // Remove the app's ApplicationDbContext registration
-            var descriptors = services.Where(
-              d => d.ServiceType == typeof(AppDbContext) ||
-                   d.ServiceType == typeof(DbContextOptions<AppDbContext>))
-                  .ToList();
-
-            foreach (var descriptor in descriptors)
-            {
-              services.Remove(descriptor);
-            }
-
-            // Add ApplicationDbContext using the Testcontainers SQL Server instance
-            services.AddDbContext<AppDbContext>((provider, options) =>
-            {
-              options.UseSqlServer(_dbContainer.GetConnectionString());
-              var interceptor = provider.GetRequiredService<EventDispatchInterceptor>();
-              options.AddInterceptors(interceptor);
-            });
+            options.UseSqlServer(connectionString);
           }
+          else
+          {
+            options.UseSqlite(connectionString);
+          }
+
+          var interceptor =
+            provider.GetRequiredService<EventDispatchInterceptor>();
+
+          options.AddInterceptors(interceptor);
         });
+      });
+  }
+
+  private static async ValueTask DisposeContainerAfterFailedStartAsync(
+    MsSqlContainer? container)
+  {
+    if (container == null)
+    {
+      return;
+    }
+
+    try
+    {
+      await container.DisposeAsync();
+    }
+    catch
+    {
+      // Preserve the original container-start exception or continue with SQLite.
+    }
   }
 }

--- a/tests/Clean.Architecture.FunctionalTests/DockerAvailabilityTests.cs
+++ b/tests/Clean.Architecture.FunctionalTests/DockerAvailabilityTests.cs
@@ -1,4 +1,5 @@
-﻿using Docker.DotNet;
+﻿using DotNet.Testcontainers.Builders;
+using Testcontainers.MsSql;
 
 namespace Clean.Architecture.FunctionalTests;
 
@@ -8,19 +9,23 @@ public class DockerAvailabilityTests
   public async Task Docker_ShouldBeRunning_ForFullFunctionalTestCoverage()
   {
     var cancellationToken = TestContext.Current.CancellationToken;
+
     try
     {
-      // Ping the Docker daemon directly using the Docker client.
-      // This has no side effects on container lifecycle or Testcontainers internals.
-      using var client = new DockerClientBuilder().Build();
-      await client.System.PingAsync(cancellationToken);
+      await using var container = new MsSqlBuilder(
+          "mcr.microsoft.com/mssql/server:2025-latest")
+        .WithPassword("Your_password123!")
+        .Build();
+
+      await container.StartAsync(cancellationToken);
     }
-    catch (Exception)
+    catch (DockerUnavailableException ex)
     {
-      Assert.Fail(
-        "Docker is not running or is misconfigured. " +
-        "Functional tests that use SQL Server will fall back to SQLite, which may not catch SQL Server-specific issues. " +
-        "For full test coverage, please start Docker Desktop (https://www.docker.com/products/docker-desktop/) and re-run the tests.");
+      Assert.Skip(
+        "Docker is not running or is unavailable. " +
+        "Functional tests can still run with SQLite, " +
+        "but SQL Server-specific behavior is not covered. " +
+        $"Error: {ex.Message}");
     }
   }
 }

--- a/tests/Clean.Architecture.FunctionalTests/SqliteFallbackTests.cs
+++ b/tests/Clean.Architecture.FunctionalTests/SqliteFallbackTests.cs
@@ -1,0 +1,44 @@
+using Clean.Architecture.Infrastructure.Data;
+using Clean.Architecture.Web.Contributors;
+using Microsoft.EntityFrameworkCore;
+
+namespace Clean.Architecture.FunctionalTests;
+
+public class SqliteFallbackTests
+{
+  [Fact]
+  public async Task UsesSqlite_WhenSqliteProviderIsSelected()
+  {
+    await using var factory =
+      CustomWebApplicationFactory<Program>.CreateWithProvider(
+        TestDatabaseProvider.Sqlite);
+
+    using var scope = factory.Services.CreateScope();
+
+    var dbContext =
+      scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+    factory.ActiveDatabaseProvider
+      .ShouldBe(TestDatabaseProvider.Sqlite);
+    dbContext.Database.IsSqlite().ShouldBeTrue();
+  }
+
+  [Fact]
+  public async Task ContributorEndpoint_WorksWithSqlite()
+  {
+    await using var factory =
+      CustomWebApplicationFactory<Program>.CreateWithProvider(
+        TestDatabaseProvider.Sqlite);
+
+    using var client = factory.CreateClient();
+
+    var result =
+      await client.GetAndDeserializeAsync<ContributorRecord>(
+        GetContributorByIdRequest.BuildRoute(1));
+
+    factory.ActiveDatabaseProvider
+      .ShouldBe(TestDatabaseProvider.Sqlite);
+    result.Id.ShouldBe(1);
+    result.Name.ShouldBe(SeedData.Contributor1Name.Value);
+  }
+}

--- a/tests/Clean.Architecture.FunctionalTests/TestDatabaseProvider.cs
+++ b/tests/Clean.Architecture.FunctionalTests/TestDatabaseProvider.cs
@@ -1,0 +1,8 @@
+namespace Clean.Architecture.FunctionalTests;
+
+public enum TestDatabaseProvider
+{
+  Auto,
+  SqlServer,
+  Sqlite
+}


### PR DESCRIPTION
## Summary

- Make the functional test database provider explicitly selectable.
- Keep SQL Server through Testcontainers as the preferred provider.
- Fall back to SQLite only when Docker is unavailable.
- Use an isolated temporary SQLite database for each test factory.
- Clean up temporary SQLite database files after the test run.
- Add tests that verify the SQLite provider and a functional endpoint using SQLite.

## Behavior

When Docker is available:

- SQL Server Testcontainers are used.
- All functional tests run with SQL Server.
- The Docker-specific test runs normally.

When Docker is unavailable:

- The functional test factory falls back to SQLite.
- The Docker-specific test is skipped.
- The remaining functional tests continue to pass.

Only `DockerUnavailableException` triggers the fallback or skipped test. Other container or SQL Server startup errors remain visible as test failures.

## Verification

With Docker running:

```text
Total tests: 6
Passed: 6
Failed: 0
Skipped: 0


## Build note

The current upstream branch reports NU1903 for the vulnerable transitive
SQLite dependency and treats all warnings as errors.

This PR keeps NU1903 visible but excludes it from `TreatWarningsAsErrors`
so the functional-test changes can be built and verified.

The actual dependency update is handled separately in #1067.