### PR TITLE
fix: apply safe_namespace to template file renames (#484)

### DIFF
--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -16,6 +16,14 @@
   "sourceName": "Clean.Architecture",
   "templateFileExtensions": [ ".cs", ".csproj", ".slnx" ],
   "preferNameDirectory": true,
+  "symbols": {
+    "safeSourceName": {
+      "type": "derived",
+      "valueSource": "name",
+      "valueTransform": "safe_namespace",
+      "fileRename": "Clean.Architecture"
+    }
+  },
   "sources": [
     {
       "include": [

--- a/MinimalClean/.template.config/template.json
+++ b/MinimalClean/.template.config/template.json
@@ -17,6 +17,14 @@
   "sourceName": "MinimalClean.Architecture",
   "templateFileExtensions": [ ".cs", ".csproj", ".slnx" ],
   "preferNameDirectory": true,
+  "symbols": {
+    "safeSourceName": {
+      "type": "derived",
+      "valueSource": "name",
+      "valueTransform": "safe_namespace",
+      "fileRename": "MinimalClean.Architecture"
+    }
+  },
   "sources": [
     {
       "include": [


### PR DESCRIPTION
Fixes #484

### Problem
When generating a solution with numbers in namespace segments (e.g., `dotnet new clean-arch -n App.2026`), `.NET` template engine applied `safe_namespace` to `.cs` and `.slnx` file contents (`_2026`), but performed literal string replacement on disk folder names (`2026`). This caused path mismatch errors in Visual Studio / Rider solution load.

### Fix
Added `safeSourceName` derived symbol with `safe_namespace` transformation and `fileRename` rule to `.template.config/template.json` in both `clean-arch` and `min-clean` templates. Disk folder names and solution paths now match consistently.